### PR TITLE
Fix HARNESS canonical gate chain

### DIFF
--- a/HARNESS.md
+++ b/HARNESS.md
@@ -16,6 +16,7 @@ A living map of the mechanical checks, policies, workflows, and artifacts that m
   1. `cargo fmt --check`
   2. `cargo clippy -- -D warnings -W clippy::complexity -W clippy::cognitive_complexity`
   3. `cargo test`
+  4. `mdbook build`
 
 There is no Makefile, npm script, or other local entrypoint. `just check` is the canonical umbrella command.
 


### PR DESCRIPTION
## Summary
- add the missing `mdbook build` step to the HARNESS canonical entry point
- align the top-level gate list with the actual `just check` recipe

## Validation
- audit run confirmed the enforced local gates pass:
  - `cargo fmt --check`
  - `cargo clippy -- -D warnings -W clippy::complexity -W clippy::cognitive_complexity`
  - `cargo test`
  - `mdbook build`