### PR TITLE
feat: Enhance Exa provider with optional fields and improved response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- **Exa**: Default `/search` `contents` now requests **highlights** (with `maxCharacters` and the user query) and a **query-scoped summary** object instead of full-page **`text`**, so the API is not asked for article bodies for normal CLI usage.
+- **Exa**: Normalized `snippet` is derived as **summary** (trimmed, capped) if non-empty, else **joined highlights** (separator ` … `, capped); **`text` is never used** as a snippet fallback, even when present in the response.
+
+### Fixed
+
+- **Exa**: Web results no longer dump full extracted page markdown into the terminal when `summary` is missing.
+
+### Added
+
+- **CLI**: News rows print **`snippet`** when present, matching web results and providers that populate `NewsResult.snippet`.

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -13,7 +13,10 @@ pub fn render_text(response: &SearchResponse) -> String {
                 lines.push(format!("{}. [{}]", i + 1, r.title));
                 lines.push(format!("   URL: {}", r.url));
                 if let Some(s) = &r.snippet {
-                    lines.push(format!("   {}", s));
+                    let t = s.trim();
+                    if !t.is_empty() {
+                        lines.push(format!("   {}", t));
+                    }
                 }
             }
             SearchResult::News(r) => {
@@ -23,7 +26,10 @@ pub fn render_text(response: &SearchResponse) -> String {
                     lines.push(format!("   Source: {}", s));
                 }
                 if let Some(s) = &r.snippet {
-                    lines.push(format!("   {}", s));
+                    let t = s.trim();
+                    if !t.is_empty() {
+                        lines.push(format!("   {}", t));
+                    }
                 }
             }
             SearchResult::Image(r) => {

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -22,6 +22,9 @@ pub fn render_text(response: &SearchResponse) -> String {
                 if let Some(s) = &r.source {
                     lines.push(format!("   Source: {}", s));
                 }
+                if let Some(s) = &r.snippet {
+                    lines.push(format!("   {}", s));
+                }
             }
             SearchResult::Image(r) => {
                 lines.push(format!("{}. [IMAGE] {}", i + 1, r.title));
@@ -57,7 +60,7 @@ mod tests {
                 SearchResult::News(NewsResult {
                     title: "Rust News".to_string(),
                     url: "https://example.com/news".to_string(),
-                    snippet: None,
+                    snippet: Some("Breaking update".to_string()),
                     source: Some("Example".to_string()),
                     published_at: None,
                 }),
@@ -84,6 +87,7 @@ mod tests {
         assert!(text.contains("Rust Lang"));
         assert!(text.contains("https://rust-lang.org"));
         assert!(text.contains("[NEWS] Rust News"));
+        assert!(text.contains("Breaking update"));
         assert!(text.contains("[IMAGE] Rust Logo"));
         assert!(text.contains("[VIDEO] Rust Tutorial"));
     }

--- a/src/providers/exa/client.rs
+++ b/src/providers/exa/client.rs
@@ -4,11 +4,17 @@ use crate::domain::query::SearchQuery;
 use crate::domain::result::SearchResponse;
 use crate::domain::types::{SafeSearch, SearchType, TimeRange};
 use crate::providers::exa::config::ExaConfig;
-use crate::providers::exa::dto::{ExaContentsRequest, ExaSearchRequest, ExaSearchResponse};
+use crate::providers::exa::dto::{
+    ExaContentsRequest, ExaHighlightsRequest, ExaSearchRequest, ExaSearchResponse,
+    ExaSummaryRequest,
+};
 use crate::providers::exa::mapper::{map_news_response, map_web_response};
 use crate::transport::http::HttpClient;
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
+
+/// Budget for Exa per-result highlights (API); mapper applies a shorter CLI-facing cap.
+const EXA_HIGHLIGHTS_MAX_CHARACTERS: u32 = 1200;
 
 pub struct ExaProvider<C: HttpClient> {
     client: C,
@@ -67,7 +73,16 @@ impl<C: HttpClient> ExaProvider<C> {
                 Some(SafeSearch::Moderate | SafeSearch::Strict) => Some(true),
                 None => None,
             },
-            contents: ExaContentsRequest { text: true },
+            contents: ExaContentsRequest {
+                text: None,
+                highlights: Some(ExaHighlightsRequest {
+                    max_characters: EXA_HIGHLIGHTS_MAX_CHARACTERS,
+                    query: Some(query.text.clone()),
+                }),
+                summary: Some(ExaSummaryRequest {
+                    query: query.text.clone(),
+                }),
+            },
         })
     }
 }
@@ -181,10 +196,28 @@ mod tests {
             assert_eq!(body.get("numResults"), Some(&Value::from(3)));
             assert_eq!(body.get("moderation"), Some(&Value::Bool(true)));
             assert_eq!(body.get("type"), Some(&Value::String("auto".to_string())));
+            let contents = body.get("contents").unwrap();
+            assert!(contents.get("text").is_none());
             assert_eq!(
-                body.get("contents")
-                    .and_then(|contents| contents.get("text")),
-                Some(&Value::Bool(true))
+                contents
+                    .get("highlights")
+                    .and_then(|h| h.get("maxCharacters"))
+                    .and_then(Value::as_u64),
+                Some(u64::from(super::EXA_HIGHLIGHTS_MAX_CHARACTERS))
+            );
+            assert_eq!(
+                contents
+                    .get("highlights")
+                    .and_then(|h| h.get("query"))
+                    .and_then(Value::as_str),
+                Some("ai news")
+            );
+            assert_eq!(
+                contents
+                    .get("summary")
+                    .and_then(|s| s.get("query"))
+                    .and_then(Value::as_str),
+                Some("ai news")
             );
 
             let start = body

--- a/src/providers/exa/dto.rs
+++ b/src/providers/exa/dto.rs
@@ -24,7 +24,27 @@ pub struct ExaSearchRequest {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ExaContentsRequest {
-    pub text: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub highlights: Option<ExaHighlightsRequest>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<ExaSummaryRequest>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExaHighlightsRequest {
+    pub max_characters: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+}
+
+/// Request-time `contents.summary` object with query (see Exa search API).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExaSummaryRequest {
+    pub query: String,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -43,6 +63,8 @@ pub struct ExaResult {
     pub url: Option<String>,
     pub published_date: Option<String>,
     pub author: Option<String>,
+    #[serde(default)]
+    pub highlights: Vec<String>,
     pub text: Option<String>,
     pub summary: Option<String>,
 }
@@ -77,9 +99,38 @@ mod tests {
                 url: Some("https://example.com".to_string()),
                 published_date: Some("2026-04-15T00:00:00.000Z".to_string()),
                 author: None,
+                highlights: vec![],
                 text: None,
                 summary: Some("Example summary".to_string()),
             }]
         );
+    }
+
+    #[test]
+    fn test_exa_search_response_deserializes_highlights_and_summary() {
+        let json = r#"{
+            "requestId": "req_456",
+            "searchType": "auto",
+            "results": [
+                {
+                    "title": "Article",
+                    "url": "https://example.com/a",
+                    "highlights": ["First excerpt.", "Second excerpt."],
+                    "summary": "One-line overview",
+                    "text": "FULL PAGE MARKDOWN WOULD BE HERE"
+                }
+            ]
+        }"#;
+
+        let response: ExaSearchResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(response.results.len(), 1);
+        let r = &response.results[0];
+        assert_eq!(
+            r.highlights,
+            vec!["First excerpt.".to_string(), "Second excerpt.".to_string()]
+        );
+        assert_eq!(r.summary.as_deref(), Some("One-line overview"));
+        assert_eq!(r.text.as_deref(), Some("FULL PAGE MARKDOWN WOULD BE HERE"));
     }
 }

--- a/src/providers/exa/mapper.rs
+++ b/src/providers/exa/mapper.rs
@@ -1,6 +1,11 @@
 use crate::domain::result::{NewsResult, SearchResponse, SearchResult, WebResult};
 use crate::providers::exa::dto::{ExaResult, ExaSearchResponse};
 
+/// Maximum characters for `snippet` shown in the CLI (after join / trim).
+const SNIPPET_DISPLAY_MAX_CHARS: usize = 500;
+
+const HIGHLIGHT_JOIN: &str = " … ";
+
 pub fn map_web_response(query: &str, dto: ExaSearchResponse) -> SearchResponse {
     SearchResponse {
         query: query.to_string(),
@@ -47,7 +52,40 @@ pub fn map_news_response(query: &str, dto: ExaSearchResponse) -> SearchResponse 
 }
 
 fn preferred_snippet(result: &ExaResult) -> Option<String> {
-    result.summary.clone().or_else(|| result.text.clone())
+    if let Some(s) = result
+        .summary
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return Some(cap_snippet_chars(s, SNIPPET_DISPLAY_MAX_CHARS));
+    }
+
+    let joined = join_highlights(&result.highlights);
+    if joined.is_empty() {
+        return None;
+    }
+
+    Some(cap_snippet_chars(&joined, SNIPPET_DISPLAY_MAX_CHARS))
+}
+
+fn join_highlights(highlights: &[String]) -> String {
+    highlights
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join(HIGHLIGHT_JOIN)
+}
+
+fn cap_snippet_chars(s: &str, max_chars: usize) -> String {
+    let count = s.chars().count();
+    if count <= max_chars {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max_chars.saturating_sub(1)).collect();
+    out.push('…');
+    out
 }
 
 #[cfg(test)]
@@ -56,18 +94,27 @@ mod tests {
     use crate::domain::result::SearchResult;
     use crate::providers::exa::dto::{ExaResult, ExaSearchResponse};
 
+    fn sample_result() -> ExaResult {
+        ExaResult {
+            title: Some("Example headline".to_string()),
+            url: Some("https://example.com/news".to_string()),
+            published_date: Some("2026-04-15T00:00:00.000Z".to_string()),
+            author: Some("Example Reporter".to_string()),
+            highlights: vec![],
+            text: None,
+            summary: Some("Short summary".to_string()),
+        }
+    }
+
     #[test]
     fn test_map_news_response_prefers_summary_and_preserves_author() {
         let dto = ExaSearchResponse {
             request_id: Some("req_123".to_string()),
             search_type: Some("auto".to_string()),
             results: vec![ExaResult {
-                title: Some("Example headline".to_string()),
-                url: Some("https://example.com/news".to_string()),
-                published_date: Some("2026-04-15T00:00:00.000Z".to_string()),
-                author: Some("Example Reporter".to_string()),
-                text: Some("Longer body text".to_string()),
-                summary: Some("Short summary".to_string()),
+                highlights: vec!["Longer body text".to_string()],
+                text: Some("IGNORED FULL TEXT".to_string()),
+                ..sample_result()
             }],
         };
 
@@ -90,6 +137,89 @@ mod tests {
                 );
             }
             other => panic!("expected news result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_map_prefers_summary_over_highlights() {
+        let dto = ExaSearchResponse {
+            request_id: None,
+            search_type: None,
+            results: vec![ExaResult {
+                summary: Some("Summary wins".to_string()),
+                highlights: vec!["Highlight A".to_string(), "Highlight B".to_string()],
+                text: Some("x".repeat(50_000)),
+                ..sample_result()
+            }],
+        };
+        let response = map_news_response("q", dto);
+        match &response.results[0] {
+            SearchResult::News(r) => assert_eq!(r.snippet.as_deref(), Some("Summary wins")),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_map_whitespace_summary_falls_through_to_highlights() {
+        let dto = ExaSearchResponse {
+            request_id: None,
+            search_type: None,
+            results: vec![ExaResult {
+                summary: Some("   \t  ".to_string()),
+                highlights: vec!["Only this".to_string()],
+                text: Some("x".repeat(10_000)),
+                ..sample_result()
+            }],
+        };
+        let response = map_news_response("q", dto);
+        match &response.results[0] {
+            SearchResult::News(r) => assert_eq!(r.snippet.as_deref(), Some("Only this")),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_map_highlights_joined_and_capped() {
+        let a = "a".repeat(350);
+        let b = "b".repeat(350);
+        let dto = ExaSearchResponse {
+            request_id: None,
+            search_type: None,
+            results: vec![ExaResult {
+                summary: None,
+                highlights: vec![a, b],
+                text: Some("SHOULD NOT APPEAR".to_string()),
+                ..sample_result()
+            }],
+        };
+        let response = map_news_response("q", dto);
+        match &response.results[0] {
+            SearchResult::News(r) => {
+                let s = r.snippet.as_ref().unwrap();
+                assert!(!s.contains("SHOULD NOT APPEAR"));
+                assert!(s.chars().count() <= 500);
+                assert!(s.ends_with('…'));
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_map_no_concise_fields_returns_none_despite_huge_text() {
+        let dto = ExaSearchResponse {
+            request_id: None,
+            search_type: None,
+            results: vec![ExaResult {
+                summary: None,
+                highlights: vec![],
+                text: Some("x".repeat(100_000)),
+                ..sample_result()
+            }],
+        };
+        let response = map_news_response("q", dto);
+        match &response.results[0] {
+            SearchResult::News(r) => assert!(r.snippet.is_none()),
+            other => panic!("{other:?}"),
         }
     }
 }


### PR DESCRIPTION
- Updated `ExaContentsRequest` to include optional `text`, `highlights`, and `summary` fields.
- Introduced `ExaHighlightsRequest` and `ExaSummaryRequest` structs for better request structuring.
- Modified `ExaResult` to include a `highlights` vector and adjusted deserialization tests accordingly.
- Updated the `ExaProvider` to utilize new request structures and handle highlights and summaries in responses.
- Enhanced mapping functions to prioritize summaries over highlights and ensure proper snippet generation for CLI output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * News search results now show snippet previews (trimmed and capped summaries or joined highlights) alongside URLs and source info.
* **Bug Fixes**
  * Web search no longer dumps full extracted page content when summaries are missing.
* **Chores**
  * Search provider requests now prefer highlights and query-scoped summaries instead of full-page text to improve snippet quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->