### PR TITLE
[codex] Add provider registry composition layer

### DIFF
--- a/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
+++ b/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
@@ -58,19 +58,19 @@ env: {target: "local", notes: "Rust CLI local implementation"}
 
 ### T005 - Replace inline provider construction in main
 - Status: completed
-- Commit: pending
+- Commit: 5129cf5
 - Files: src/main.rs
 - Commands: `cargo check` -> pass; `env -u BRAVE_API_KEY -u EXA_API_KEY cargo run -- "rust"` -> exits 1 with `provider `brave` is unavailable; configured providers: []`
 - Tests: missing-key CLI acceptance proof pass
 - Notes: Main now builds the selected service through the production registry before search execution.
 
 ### T006 - Extend architecture guardrails for the composition layer
-- Status: pending
+- Status: completed
 - Commit: pending
-- Files: pending
-- Commands: pending
-- Tests: pending
-- Notes: pending
+- Files: tests/architecture_test.rs
+- Commands: `cargo test --test architecture_test` -> pass
+- Tests: architecture boundary tests pass, including bootstrap no-CLI guard
+- Notes: Existing layer checks unchanged; bootstrap remains allowed to compose app, providers, transport, and domain.
 
 ### T007 - Add focused registry tests
 - Status: pending

--- a/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
+++ b/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
@@ -50,19 +50,19 @@ env: {target: "local", notes: "Rust CLI local implementation"}
 
 ### T004 - Convert CliProvider to ProviderId at the binary edge
 - Status: completed
-- Commit: pending
+- Commit: e441cb9
 - Files: src/main.rs
 - Commands: `cargo test cli::args::tests::test_cli_provider_parses_exa_and_defaults_to_brave` -> pass
 - Tests: CLI provider parsing regression test pass
 - Notes: Conversion lives in the binary edge; bootstrap remains CLI-independent.
 
 ### T005 - Replace inline provider construction in main
-- Status: pending
+- Status: completed
 - Commit: pending
-- Files: pending
-- Commands: pending
-- Tests: pending
-- Notes: pending
+- Files: src/main.rs
+- Commands: `cargo check` -> pass; `env -u BRAVE_API_KEY -u EXA_API_KEY cargo run -- "rust"` -> exits 1 with `provider `brave` is unavailable; configured providers: []`
+- Tests: missing-key CLI acceptance proof pass
+- Notes: Main now builds the selected service through the production registry before search execution.
 
 ### T006 - Extend architecture guardrails for the composition layer
 - Status: pending

--- a/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
+++ b/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
@@ -42,19 +42,19 @@ env: {target: "local", notes: "Rust CLI local implementation"}
 
 ### T003 - Add production registry that only includes configured providers
 - Status: completed
-- Commit: pending
+- Commit: d942b93
 - Files: src/bootstrap/provider_registry.rs
 - Commands: `cargo test bootstrap::provider_registry` -> pass
 - Tests: env-backed production availability test pass
 - Notes: Registered Brave and Exa only when typed env config constructors succeed; missing or non-Unicode keys omit providers.
 
 ### T004 - Convert CliProvider to ProviderId at the binary edge
-- Status: pending
+- Status: completed
 - Commit: pending
-- Files: pending
-- Commands: pending
-- Tests: pending
-- Notes: pending
+- Files: src/main.rs
+- Commands: `cargo test cli::args::tests::test_cli_provider_parses_exa_and_defaults_to_brave` -> pass
+- Tests: CLI provider parsing regression test pass
+- Notes: Conversion lives in the binary edge; bootstrap remains CLI-independent.
 
 ### T005 - Replace inline provider construction in main
 - Status: pending

--- a/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
+++ b/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
@@ -1,0 +1,104 @@
+---
+title: "Provider registry execution log"
+link: "provider-registry-execute"
+type: debug_history
+ontological_relations:
+  - relates_to: [[provider-registry-plan]]
+tags: [execute, provider-registry]
+uuid: "F4655A49-209E-4388-B038-F01351808759"
+created_at: "2026-04-25T21:24:49Z"
+owner: "tuna"
+plan_path: ".artifacts/plan/2026-04-25_13-50-32_provider-registry/PLAN.md"
+start_commit: "39c796e"
+rollback_commit: "7267aaa"
+env: {target: "local", notes: "Rust CLI local implementation"}
+---
+
+## Pre-Flight Checks
+- Branch: redesign-main-search-interface
+- Rollback: 7267aaa
+- DoR: satisfied
+- Ready: yes
+- Access/secrets: not required for implementation; live API calls require provider env vars
+- Fixtures/data: ready
+
+## Task Execution
+
+### T001 - Add bootstrap module skeleton and ProviderId
+- Status: completed
+- Commit: pending
+- Files: src/main.rs; src/bootstrap/mod.rs; src/bootstrap/provider_registry.rs
+- Commands: `cargo check` -> pass with expected temporary dead-code warning for ProviderId
+- Tests: cargo check pass
+- Notes: Added composition module skeleton only; production provider behavior unchanged.
+
+### T002 - Define registry and construction error contract
+- Status: pending
+- Commit: pending
+- Files: pending
+- Commands: pending
+- Tests: pending
+- Notes: pending
+
+### T003 - Add production registry that only includes configured providers
+- Status: pending
+- Commit: pending
+- Files: pending
+- Commands: pending
+- Tests: pending
+- Notes: pending
+
+### T004 - Convert CliProvider to ProviderId at the binary edge
+- Status: pending
+- Commit: pending
+- Files: pending
+- Commands: pending
+- Tests: pending
+- Notes: pending
+
+### T005 - Replace inline provider construction in main
+- Status: pending
+- Commit: pending
+- Files: pending
+- Commands: pending
+- Tests: pending
+- Notes: pending
+
+### T006 - Extend architecture guardrails for the composition layer
+- Status: pending
+- Commit: pending
+- Files: pending
+- Commands: pending
+- Tests: pending
+- Notes: pending
+
+### T007 - Add focused registry tests
+- Status: pending
+- Commit: pending
+- Files: pending
+- Commands: pending
+- Tests: pending
+- Notes: pending
+
+### T008 - Run final local gate and update docs only if source references require it
+- Status: pending
+- Commit: pending
+- Files: pending
+- Commands: pending
+- Tests: pending
+- Notes: pending
+
+## Gate Results
+- Tests: pending
+- Type checks: pending
+- Linters: pending
+- Docs build: pending
+- Umbrella gate: pending
+
+## Issues & Resolutions
+- None yet
+
+## Success Criteria
+- [ ] All planned gates passed
+- [ ] Execution log saved
+- [ ] Source references updated only where required

--- a/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
+++ b/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
@@ -66,19 +66,19 @@ env: {target: "local", notes: "Rust CLI local implementation"}
 
 ### T006 - Extend architecture guardrails for the composition layer
 - Status: completed
-- Commit: pending
+- Commit: 0b6eeac
 - Files: tests/architecture_test.rs
 - Commands: `cargo test --test architecture_test` -> pass
 - Tests: architecture boundary tests pass, including bootstrap no-CLI guard
 - Notes: Existing layer checks unchanged; bootstrap remains allowed to compose app, providers, transport, and domain.
 
 ### T007 - Add focused registry tests
-- Status: pending
+- Status: completed
 - Commit: pending
-- Files: pending
-- Commands: pending
-- Tests: pending
-- Notes: pending
+- Files: src/bootstrap/provider_registry.rs
+- Commands: `cargo test bootstrap::provider_registry` -> pass
+- Tests: registry unavailable, env availability, successful build, and stable ordering tests pass
+- Notes: Pure registry tests use a local MockProvider and remain separate from env mutation test.
 
 ### T008 - Run final local gate and update docs only if source references require it
 - Status: pending

--- a/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
+++ b/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
@@ -34,19 +34,19 @@ env: {target: "local", notes: "Rust CLI local implementation"}
 
 ### T002 - Define registry and construction error contract
 - Status: completed
-- Commit: pending
+- Commit: 8886c96
 - Files: src/bootstrap/provider_registry.rs
 - Commands: `cargo test bootstrap::provider_registry::tests::empty_registry_reports_provider_unavailable` -> pass
 - Tests: focused unavailable-provider unit test pass
 - Notes: Added registry builder map, stable availability ordering, and ProviderUnavailable construction error.
 
 ### T003 - Add production registry that only includes configured providers
-- Status: pending
+- Status: completed
 - Commit: pending
-- Files: pending
-- Commands: pending
-- Tests: pending
-- Notes: pending
+- Files: src/bootstrap/provider_registry.rs
+- Commands: `cargo test bootstrap::provider_registry` -> pass
+- Tests: env-backed production availability test pass
+- Notes: Registered Brave and Exa only when typed env config constructors succeed; missing or non-Unicode keys omit providers.
 
 ### T004 - Convert CliProvider to ProviderId at the binary edge
 - Status: pending

--- a/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
+++ b/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
@@ -11,6 +11,7 @@ owner: "tuna"
 plan_path: ".artifacts/plan/2026-04-25_13-50-32_provider-registry/PLAN.md"
 start_commit: "39c796e"
 rollback_commit: "7267aaa"
+end_commit: "final T008 commit"
 env: {target: "local", notes: "Rust CLI local implementation"}
 ---
 
@@ -74,31 +75,31 @@ env: {target: "local", notes: "Rust CLI local implementation"}
 
 ### T007 - Add focused registry tests
 - Status: completed
-- Commit: pending
+- Commit: 7ada3e1
 - Files: src/bootstrap/provider_registry.rs
 - Commands: `cargo test bootstrap::provider_registry` -> pass
 - Tests: registry unavailable, env availability, successful build, and stable ordering tests pass
 - Notes: Pure registry tests use a local MockProvider and remain separate from env mutation test.
 
 ### T008 - Run final local gate and update docs only if source references require it
-- Status: pending
-- Commit: pending
-- Files: pending
-- Commands: pending
-- Tests: pending
-- Notes: pending
+- Status: completed
+- Commit: final T008 commit
+- Files: HARNESS.md; docs/architecture.md; src/bootstrap/provider_registry.rs
+- Commands: `cargo fmt` -> pass; `cargo test` -> 22 unit tests and 6 architecture tests pass; `cargo clippy -- -D warnings -W clippy::complexity -W clippy::cognitive_complexity` -> pass; `mdbook build` -> pass after installing missing mdBook tool; `just check` -> pass
+- Tests: full repository gate pass
+- Notes: Updated architecture docs and HARNESS rows affected by the new bootstrap layer. Initial `mdbook build` failed because `mdbook` was not installed; installed `mdbook v0.5.2` with `cargo install mdbook --locked`, then docs and umbrella gates passed.
 
 ## Gate Results
-- Tests: pending
-- Type checks: pending
-- Linters: pending
-- Docs build: pending
-- Umbrella gate: pending
+- Tests: pass (`cargo test`: 22 unit tests + 6 architecture tests)
+- Type checks: pass via `cargo clippy`
+- Linters: pass (`cargo fmt --check` and clippy in `just check`)
+- Docs build: pass (`mdbook build`)
+- Umbrella gate: pass (`just check`)
 
 ## Issues & Resolutions
-- None yet
+- T008 - `mdbook` was missing from PATH -> installed `mdbook v0.5.2` using Cargo and reran docs/umbrella gates successfully.
 
 ## Success Criteria
-- [ ] All planned gates passed
-- [ ] Execution log saved
-- [ ] Source references updated only where required
+- [x] All planned gates passed
+- [x] Execution log saved
+- [x] Source references updated only where required

--- a/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
+++ b/.artifacts/execute/2026-04-25_21-24-49_provider-registry.md
@@ -26,19 +26,19 @@ env: {target: "local", notes: "Rust CLI local implementation"}
 
 ### T001 - Add bootstrap module skeleton and ProviderId
 - Status: completed
-- Commit: pending
+- Commit: 9e0087d
 - Files: src/main.rs; src/bootstrap/mod.rs; src/bootstrap/provider_registry.rs
 - Commands: `cargo check` -> pass with expected temporary dead-code warning for ProviderId
 - Tests: cargo check pass
 - Notes: Added composition module skeleton only; production provider behavior unchanged.
 
 ### T002 - Define registry and construction error contract
-- Status: pending
+- Status: completed
 - Commit: pending
-- Files: pending
-- Commands: pending
-- Tests: pending
-- Notes: pending
+- Files: src/bootstrap/provider_registry.rs
+- Commands: `cargo test bootstrap::provider_registry::tests::empty_registry_reports_provider_unavailable` -> pass
+- Tests: focused unavailable-provider unit test pass
+- Notes: Added registry builder map, stable availability ordering, and ProviderUnavailable construction error.
 
 ### T003 - Add production registry that only includes configured providers
 - Status: pending

--- a/.artifacts/interface-designs/search-service-flow-visual.html
+++ b/.artifacts/interface-designs/search-service-flow-visual.html
@@ -1,0 +1,289 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Search Service Wiring Visual</title>
+    <style>
+      body {
+        margin: 0;
+        background: #020617;
+        color: #e5edf4;
+        font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+      }
+      main {
+        max-width: 1460px;
+        margin: 0 auto;
+        padding: 28px 18px 42px;
+      }
+      h1 {
+        margin: 0;
+        font-size: 30px;
+        letter-spacing: 0;
+      }
+      p {
+        color: #9fb0c3;
+        margin: 8px 0 20px;
+        max-width: 960px;
+        line-height: 1.55;
+      }
+      .frame {
+        border: 1px solid #1e293b;
+        border-radius: 12px;
+        overflow: auto;
+        background: #020617;
+        box-shadow: 0 24px 70px rgba(0, 0, 0, 0.35);
+      }
+      .cards {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 14px;
+        margin-top: 16px;
+      }
+      .card {
+        border: 1px solid #1e293b;
+        border-radius: 10px;
+        background: #0f172a;
+        padding: 14px;
+      }
+      .card h2 {
+        margin: 0 0 8px;
+        font-size: 15px;
+        letter-spacing: 0;
+      }
+      .card p {
+        margin: 0;
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>SearchService Wiring: What Actually Changes</h1>
+      <p>
+        This diagram is about the construction path around <strong>provider selection</strong>.
+        No search request is sent until <strong>service.search(query).await</strong>. The design question is:
+        how much wiring should <strong>main</strong> see?
+      </p>
+
+      <div class="frame">
+        <svg width="1420" height="1040" viewBox="0 0 1420 1040" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Search service interface design options">
+          <defs>
+            <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+              <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+            </pattern>
+            <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+              <path d="M0,0 L0,6 L9,3 z" fill="#94a3b8"/>
+            </marker>
+            <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+              <path d="M0,0 L0,6 L9,3 z" fill="#34d399"/>
+            </marker>
+            <marker id="arrowRose" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+              <path d="M0,0 L0,6 L9,3 z" fill="#fb7185"/>
+            </marker>
+            <style>
+              .title { fill: #f8fafc; font-size: 18px; font-weight: 700; }
+              .label { fill: #e2e8f0; font-size: 13px; font-weight: 700; }
+              .sub { fill: #94a3b8; font-size: 10px; }
+              .tiny { fill: #cbd5e1; font-size: 9px; }
+              .note { fill: #f8fafc; font-size: 11px; font-weight: 700; }
+            </style>
+          </defs>
+
+          <rect width="1420" height="1040" fill="#020617"/>
+          <rect width="1420" height="1040" fill="url(#grid)" opacity="0.8"/>
+
+          <!-- Section boundaries -->
+          <rect x="28" y="34" width="1364" height="270" rx="14" fill="rgba(136,19,55,.12)" stroke="#fb7185" stroke-width="1.5" stroke-dasharray="8 5"/>
+          <rect x="28" y="336" width="432" height="648" rx="14" fill="rgba(6,78,59,.16)" stroke="#34d399" stroke-width="1.5"/>
+          <rect x="494" y="336" width="432" height="648" rx="14" fill="rgba(76,29,149,.16)" stroke="#a78bfa" stroke-width="1.5"/>
+          <rect x="960" y="336" width="432" height="648" rx="14" fill="rgba(120,53,15,.14)" stroke="#fbbf24" stroke-width="1.5"/>
+
+          <text x="52" y="68" class="title">Current: main is the wiring diagram</text>
+          <text x="52" y="92" class="sub">The branch does config loading, process exit, HTTP client creation, provider construction, boxing, and service construction.</text>
+
+          <text x="52" y="370" class="title">Option 1: Narrow Factory</text>
+          <text x="518" y="370" class="title">Option 2: Registry Factory</text>
+          <text x="984" y="370" class="title">Option 3: CLI App Runner</text>
+
+          <!-- Current flow arrows -->
+          <path d="M178 160 H314" stroke="#fb7185" stroke-width="2.2" fill="none" marker-end="url(#arrowRose)"/>
+          <path d="M430 160 H566" stroke="#fb7185" stroke-width="2.2" fill="none" marker-end="url(#arrowRose)"/>
+          <path d="M682 160 H818" stroke="#fb7185" stroke-width="2.2" fill="none" marker-end="url(#arrowRose)"/>
+          <path d="M934 160 H1070" stroke="#fb7185" stroke-width="2.2" fill="none" marker-end="url(#arrowRose)"/>
+          <path d="M1186 160 H1322" stroke="#fb7185" stroke-width="2.2" fill="none" marker-end="url(#arrowRose)"/>
+
+          <!-- Current boxes -->
+          <rect x="62" y="122" width="116" height="76" rx="7" fill="#0f172a"/>
+          <rect x="62" y="122" width="116" height="76" rx="7" fill="rgba(8,51,68,.45)" stroke="#22d3ee" stroke-width="1.5"/>
+          <text x="120" y="153" text-anchor="middle" class="label">main</text>
+          <text x="120" y="172" text-anchor="middle" class="sub">args.provider</text>
+
+          <rect x="314" y="122" width="116" height="76" rx="7" fill="#0f172a"/>
+          <rect x="314" y="122" width="116" height="76" rx="7" fill="rgba(136,19,55,.4)" stroke="#fb7185" stroke-width="1.5"/>
+          <text x="372" y="148" text-anchor="middle" class="label">match</text>
+          <text x="372" y="167" text-anchor="middle" class="sub">Brave / Exa</text>
+          <text x="372" y="182" text-anchor="middle" class="sub">exit on config error</text>
+
+          <rect x="566" y="122" width="116" height="76" rx="7" fill="#0f172a"/>
+          <rect x="566" y="122" width="116" height="76" rx="7" fill="rgba(120,53,15,.35)" stroke="#fbbf24" stroke-width="1.5"/>
+          <text x="624" y="148" text-anchor="middle" class="label">Config</text>
+          <text x="624" y="167" text-anchor="middle" class="sub">from_env()</text>
+          <text x="624" y="182" text-anchor="middle" class="sub">provider-specific</text>
+
+          <rect x="818" y="122" width="116" height="76" rx="7" fill="#0f172a"/>
+          <rect x="818" y="122" width="116" height="76" rx="7" fill="rgba(30,41,59,.6)" stroke="#94a3b8" stroke-width="1.5"/>
+          <text x="876" y="148" text-anchor="middle" class="label">HTTP</text>
+          <text x="876" y="167" text-anchor="middle" class="sub">Reqwest</text>
+          <text x="876" y="182" text-anchor="middle" class="sub">client wrapper</text>
+
+          <rect x="1070" y="122" width="116" height="76" rx="7" fill="#0f172a"/>
+          <rect x="1070" y="122" width="116" height="76" rx="7" fill="rgba(6,78,59,.4)" stroke="#34d399" stroke-width="1.5"/>
+          <text x="1128" y="148" text-anchor="middle" class="label">Provider</text>
+          <text x="1128" y="167" text-anchor="middle" class="sub">BraveProvider</text>
+          <text x="1128" y="182" text-anchor="middle" class="sub">or ExaProvider</text>
+
+          <rect x="1322" y="122" width="56" height="76" rx="7" fill="#0f172a"/>
+          <rect x="1322" y="122" width="56" height="76" rx="7" fill="rgba(76,29,149,.45)" stroke="#a78bfa" stroke-width="1.5"/>
+          <text x="1350" y="151" text-anchor="middle" class="label">Svc</text>
+          <text x="1350" y="169" text-anchor="middle" class="sub">boxed</text>
+
+          <rect x="252" y="232" width="916" height="42" rx="7" fill="rgba(136,19,55,.24)" stroke="#fb7185"/>
+          <text x="710" y="258" text-anchor="middle" class="note">Smell: the top-level command path must read every provider's construction recipe</text>
+
+          <!-- Option 1 -->
+          <path d="M118 484 H210" stroke="#34d399" stroke-width="2.2" fill="none" marker-end="url(#arrowGreen)"/>
+          <path d="M298 484 H390" stroke="#34d399" stroke-width="2.2" fill="none" marker-end="url(#arrowGreen)"/>
+          <path d="M250 544 V618" stroke="#34d399" stroke-width="2" fill="none" marker-end="url(#arrowGreen)"/>
+
+          <rect x="62" y="438" width="112" height="92" rx="7" fill="#0f172a"/>
+          <rect x="62" y="438" width="112" height="92" rx="7" fill="rgba(8,51,68,.45)" stroke="#22d3ee" stroke-width="1.5"/>
+          <text x="118" y="474" text-anchor="middle" class="label">main</text>
+          <text x="118" y="493" text-anchor="middle" class="sub">parse args</text>
+          <text x="118" y="508" text-anchor="middle" class="sub">handle exit</text>
+
+          <rect x="210" y="426" width="88" height="116" rx="7" fill="#0f172a"/>
+          <rect x="210" y="426" width="88" height="116" rx="7" fill="rgba(6,78,59,.45)" stroke="#34d399" stroke-width="1.5"/>
+          <text x="254" y="459" text-anchor="middle" class="label">build</text>
+          <text x="254" y="477" text-anchor="middle" class="label">service</text>
+          <text x="254" y="500" text-anchor="middle" class="sub">one function</text>
+          <text x="254" y="515" text-anchor="middle" class="sub">owns match</text>
+
+          <rect x="342" y="438" width="82" height="92" rx="7" fill="#0f172a"/>
+          <rect x="342" y="438" width="82" height="92" rx="7" fill="rgba(76,29,149,.45)" stroke="#a78bfa" stroke-width="1.5"/>
+          <text x="383" y="476" text-anchor="middle" class="label">Search</text>
+          <text x="383" y="494" text-anchor="middle" class="label">Service</text>
+
+          <rect x="94" y="618" width="312" height="170" rx="8" fill="#0f172a"/>
+          <rect x="94" y="618" width="312" height="170" rx="8" fill="rgba(15,23,42,.72)" stroke="#334155"/>
+          <text x="250" y="646" text-anchor="middle" class="label">hidden inside factory</text>
+          <text x="128" y="678" class="tiny">• BraveConfig::from_env()</text>
+          <text x="128" y="704" class="tiny">• ExaConfig::from_env()</text>
+          <text x="128" y="730" class="tiny">• ReqwestHttpClient::new()</text>
+          <text x="128" y="756" class="tiny">• Provider constructors + Box</text>
+
+          <rect x="74" y="842" width="352" height="76" rx="8" fill="rgba(6,78,59,.3)" stroke="#34d399"/>
+          <text x="250" y="872" text-anchor="middle" class="note">Best default</text>
+          <text x="250" y="896" text-anchor="middle" class="sub">small interface, no new framework</text>
+
+          <!-- Option 2 -->
+          <path d="M584 484 H676" stroke="#a78bfa" stroke-width="2.2" fill="none" marker-end="url(#arrow)"/>
+          <path d="M764 484 H856" stroke="#a78bfa" stroke-width="2.2" fill="none" marker-end="url(#arrow)"/>
+          <path d="M710 548 V618" stroke="#a78bfa" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+
+          <rect x="528" y="438" width="112" height="92" rx="7" fill="#0f172a"/>
+          <rect x="528" y="438" width="112" height="92" rx="7" fill="rgba(8,51,68,.45)" stroke="#22d3ee" stroke-width="1.5"/>
+          <text x="584" y="474" text-anchor="middle" class="label">main</text>
+          <text x="584" y="493" text-anchor="middle" class="sub">selects name</text>
+          <text x="584" y="508" text-anchor="middle" class="sub">handles exit</text>
+
+          <rect x="676" y="420" width="88" height="128" rx="7" fill="#0f172a"/>
+          <rect x="676" y="420" width="88" height="128" rx="7" fill="rgba(76,29,149,.45)" stroke="#a78bfa" stroke-width="1.5"/>
+          <text x="720" y="454" text-anchor="middle" class="label">Factory</text>
+          <text x="720" y="478" text-anchor="middle" class="sub">registry</text>
+          <text x="720" y="493" text-anchor="middle" class="sub">config source</text>
+          <text x="720" y="508" text-anchor="middle" class="sub">http factory</text>
+
+          <rect x="808" y="438" width="82" height="92" rx="7" fill="#0f172a"/>
+          <rect x="808" y="438" width="82" height="92" rx="7" fill="rgba(76,29,149,.45)" stroke="#a78bfa" stroke-width="1.5"/>
+          <text x="849" y="476" text-anchor="middle" class="label">Search</text>
+          <text x="849" y="494" text-anchor="middle" class="label">Service</text>
+
+          <rect x="558" y="618" width="304" height="170" rx="8" fill="#0f172a"/>
+          <rect x="558" y="618" width="304" height="170" rx="8" fill="rgba(15,23,42,.72)" stroke="#334155"/>
+          <text x="710" y="646" text-anchor="middle" class="label">replaceable parts</text>
+          <text x="592" y="678" class="tiny">• ProviderRegistry</text>
+          <text x="592" y="704" class="tiny">• ProviderConfigSource</text>
+          <text x="592" y="730" class="tiny">• HttpClientFactory</text>
+          <text x="592" y="756" class="tiny">• ProviderSelection::Named(...)</text>
+
+          <rect x="540" y="842" width="352" height="76" rx="8" fill="rgba(76,29,149,.3)" stroke="#a78bfa"/>
+          <text x="716" y="872" text-anchor="middle" class="note">Best when growth is real</text>
+          <text x="716" y="896" text-anchor="middle" class="sub">more extensible, more surface area</text>
+
+          <!-- Option 3 -->
+          <path d="M1050 484 H1142" stroke="#fbbf24" stroke-width="2.2" fill="none" marker-end="url(#arrow)"/>
+          <path d="M1230 484 H1322" stroke="#fbbf24" stroke-width="2.2" fill="none" marker-end="url(#arrow)"/>
+          <path d="M1184 548 V618" stroke="#fbbf24" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+
+          <rect x="994" y="438" width="112" height="92" rx="7" fill="#0f172a"/>
+          <rect x="994" y="438" width="112" height="92" rx="7" fill="rgba(8,51,68,.45)" stroke="#22d3ee" stroke-width="1.5"/>
+          <text x="1050" y="474" text-anchor="middle" class="label">main</text>
+          <text x="1050" y="493" text-anchor="middle" class="sub">build command</text>
+          <text x="1050" y="508" text-anchor="middle" class="sub">render result</text>
+
+          <rect x="1142" y="420" width="88" height="128" rx="7" fill="#0f172a"/>
+          <rect x="1142" y="420" width="88" height="128" rx="7" fill="rgba(120,53,15,.35)" stroke="#fbbf24" stroke-width="1.5"/>
+          <text x="1186" y="454" text-anchor="middle" class="label">CLI App</text>
+          <text x="1186" y="478" text-anchor="middle" class="sub">run(command)</text>
+          <text x="1186" y="493" text-anchor="middle" class="sub">build service</text>
+          <text x="1186" y="508" text-anchor="middle" class="sub">search</text>
+
+          <rect x="1274" y="438" width="82" height="92" rx="7" fill="#0f172a"/>
+          <rect x="1274" y="438" width="82" height="92" rx="7" fill="rgba(6,78,59,.45)" stroke="#34d399" stroke-width="1.5"/>
+          <text x="1315" y="476" text-anchor="middle" class="label">Search</text>
+          <text x="1315" y="494" text-anchor="middle" class="label">Response</text>
+
+          <rect x="1024" y="618" width="304" height="170" rx="8" fill="#0f172a"/>
+          <rect x="1024" y="618" width="304" height="170" rx="8" fill="rgba(15,23,42,.72)" stroke="#334155"/>
+          <text x="1176" y="646" text-anchor="middle" class="label">hidden in runner</text>
+          <text x="1058" y="678" class="tiny">• build SearchQuery/SearchCommand</text>
+          <text x="1058" y="704" class="tiny">• select provider</text>
+          <text x="1058" y="730" class="tiny">• construct service</text>
+          <text x="1058" y="756" class="tiny">• call service.search(...)</text>
+
+          <rect x="1006" y="842" width="352" height="76" rx="8" fill="rgba(120,53,15,.3)" stroke="#fbbf24"/>
+          <text x="1182" y="872" text-anchor="middle" class="note">Best for command-oriented CLI</text>
+          <text x="1182" y="896" text-anchor="middle" class="sub">clean top level, less reusable service access</text>
+
+          <!-- Legend -->
+          <rect x="52" y="996" width="16" height="16" rx="3" fill="rgba(8,51,68,.45)" stroke="#22d3ee"/>
+          <text x="78" y="1008" class="tiny">CLI edge</text>
+          <rect x="176" y="996" width="16" height="16" rx="3" fill="rgba(6,78,59,.45)" stroke="#34d399"/>
+          <text x="202" y="1008" class="tiny">application/composition</text>
+          <rect x="376" y="996" width="16" height="16" rx="3" fill="rgba(76,29,149,.45)" stroke="#a78bfa"/>
+          <text x="402" y="1008" class="tiny">service/factory abstraction</text>
+          <rect x="614" y="996" width="16" height="16" rx="3" fill="rgba(120,53,15,.35)" stroke="#fbbf24"/>
+          <text x="640" y="1008" class="tiny">config/runtime</text>
+          <rect x="786" y="996" width="16" height="16" rx="3" fill="rgba(136,19,55,.4)" stroke="#fb7185"/>
+          <text x="812" y="1008" class="tiny">smelly coupling</text>
+        </svg>
+      </div>
+
+      <section class="cards">
+        <article class="card">
+          <h2 style="color:#34d399;">The likely move</h2>
+          <p>Use Option 1 first: one composition helper moves the messy provider wiring out of main while keeping the model easy to read.</p>
+        </article>
+        <article class="card">
+          <h2 style="color:#a78bfa;">What not to do yet</h2>
+          <p>Do not introduce the registry unless provider count, config sources, or test injection pressure actually grows.</p>
+        </article>
+        <article class="card">
+          <h2 style="color:#fbbf24;">The conceptual split</h2>
+          <p>Construction happens before the request. Execution starts at service.search(query).await.</p>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/.artifacts/interface-designs/search-service-interface-options.html
+++ b/.artifacts/interface-designs/search-service-interface-options.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Search Service Interface Options</title>
+  </head>
+  <body style="margin:0;background:#f7f4ee;color:#1e2428;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;line-height:1.45;">
+    <main style="max-width:1220px;margin:0 auto;padding:34px 22px 48px;">
+      <section style="margin-bottom:26px;border-bottom:1px solid #d9d2c6;padding-bottom:22px;">
+        <p style="margin:0 0 7px;color:#6b6258;font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;">Provider construction interface</p>
+        <h1 style="margin:0;font-size:clamp(30px,4vw,56px);line-height:1.02;letter-spacing:0;color:#202629;">Three Ways To Replace The Inline Match</h1>
+        <p style="max-width:820px;margin:14px 0 0;color:#4d5559;font-size:17px;">The current smell is not that HTTP requests are being made in <code style="background:#efe8dd;border:1px solid #ded4c5;border-radius:5px;padding:2px 5px;">main</code>. The smell is that <code style="background:#efe8dd;border:1px solid #ded4c5;border-radius:5px;padding:2px 5px;">main</code> is manually wiring config, HTTP transport, concrete providers, boxing, and service construction for every provider.</p>
+      </section>
+
+      <section style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:18px;align-items:stretch;">
+        <article style="background:#ffffff;border:1px solid #d8d0c3;border-top:7px solid #0f7c80;border-radius:8px;padding:20px;box-shadow:0 1px 2px rgba(30,36,40,.06);">
+          <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px;">
+            <span style="display:inline-grid;place-items:center;width:34px;height:34px;border-radius:50%;background:#0f7c80;color:white;font-weight:800;">1</span>
+            <div>
+              <h2 style="font-size:22px;margin:0;color:#162022;letter-spacing:0;">Narrow Factory</h2>
+              <p style="margin:2px 0 0;color:#667074;font-size:13px;">Smallest practical interface</p>
+            </div>
+          </div>
+
+          <div style="margin:16px 0 13px;">
+            <p style="margin:0 0 6px;font-size:12px;font-weight:800;color:#6b6258;text-transform:uppercase;letter-spacing:.08em;">Interface</p>
+            <pre style="white-space:pre-wrap;overflow:auto;margin:0;background:#1f2629;color:#f4efe6;border-radius:7px;padding:13px;font-size:13px;line-height:1.45;"><code>pub fn build_search_service(
+    provider: CliProvider,
+) -&gt; Result&lt;SearchService, BuildServiceError&gt;;</code></pre>
+          </div>
+
+          <div style="margin:16px 0 13px;">
+            <p style="margin:0 0 6px;font-size:12px;font-weight:800;color:#6b6258;text-transform:uppercase;letter-spacing:.08em;">Caller</p>
+            <pre style="white-space:pre-wrap;overflow:auto;margin:0;background:#f5f1ea;border:1px solid #ddd4c7;border-radius:7px;padding:13px;font-size:13px;line-height:1.45;"><code>let service = build_search_service(args.provider)
+    .unwrap_or_else(exit_with_error);
+
+let response = service.search(query).await?;</code></pre>
+          </div>
+
+          <p style="margin:14px 0 7px;font-weight:800;color:#202629;">Hides</p>
+          <p style="margin:0;color:#4c5559;font-size:14px;">Provider config loading, <code style="background:#efe8dd;border:1px solid #ded4c5;border-radius:5px;padding:1px 4px;">ReqwestHttpClient</code>, concrete provider constructors, boxing, and <code style="background:#efe8dd;border:1px solid #ded4c5;border-radius:5px;padding:1px 4px;">SearchService::new</code>.</p>
+
+          <p style="margin:14px 0 7px;font-weight:800;color:#202629;">Trade-off</p>
+          <p style="margin:0;color:#4c5559;font-size:14px;">Best fit for now. It removes duplication without inventing a provider system. The branch still exists, but it lives in one composition function instead of the CLI flow.</p>
+        </article>
+
+        <article style="background:#ffffff;border:1px solid #d8d0c3;border-top:7px solid #7b4ab3;border-radius:8px;padding:20px;box-shadow:0 1px 2px rgba(30,36,40,.06);">
+          <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px;">
+            <span style="display:inline-grid;place-items:center;width:34px;height:34px;border-radius:50%;background:#7b4ab3;color:white;font-weight:800;">2</span>
+            <div>
+              <h2 style="font-size:22px;margin:0;color:#21172b;letter-spacing:0;">Registry Factory</h2>
+              <p style="margin:2px 0 0;color:#667074;font-size:13px;">Most extensible shape</p>
+            </div>
+          </div>
+
+          <div style="margin:16px 0 13px;">
+            <p style="margin:0 0 6px;font-size:12px;font-weight:800;color:#6b6258;text-transform:uppercase;letter-spacing:.08em;">Interface</p>
+            <pre style="white-space:pre-wrap;overflow:auto;margin:0;background:#1f2629;color:#f4efe6;border-radius:7px;padding:13px;font-size:13px;line-height:1.45;"><code>pub struct SearchServiceFactory { ... }
+
+impl SearchServiceFactory {
+    pub fn production() -&gt; Self;
+    pub fn with_parts(
+        registry: ProviderRegistry,
+        config: Box&lt;dyn ProviderConfigSource&gt;,
+        http: Box&lt;dyn HttpClientFactory&gt;,
+    ) -&gt; Self;
+    pub fn build(
+        &amp;self,
+        provider: ProviderSelection,
+    ) -&gt; Result&lt;SearchService, FactoryError&gt;;
+}</code></pre>
+          </div>
+
+          <div style="margin:16px 0 13px;">
+            <p style="margin:0 0 6px;font-size:12px;font-weight:800;color:#6b6258;text-transform:uppercase;letter-spacing:.08em;">Caller</p>
+            <pre style="white-space:pre-wrap;overflow:auto;margin:0;background:#f5f1ea;border:1px solid #ddd4c7;border-radius:7px;padding:13px;font-size:13px;line-height:1.45;"><code>let provider = ProviderSelection::from(args.provider);
+
+let service = SearchServiceFactory::production()
+    .build(provider)
+    .unwrap_or_else(exit_with_error);</code></pre>
+          </div>
+
+          <p style="margin:14px 0 7px;font-weight:800;color:#202629;">Hides</p>
+          <p style="margin:0;color:#4c5559;font-size:14px;">All provider construction plus where config comes from, how HTTP clients are created, and how provider names map to constructors.</p>
+
+          <p style="margin:14px 0 7px;font-weight:800;color:#202629;">Trade-off</p>
+          <p style="margin:0;color:#4c5559;font-size:14px;">Good if providers or config sources are about to multiply. Heavy for a two-provider CLI because it adds registry and factory abstractions before the code clearly needs them.</p>
+        </article>
+
+        <article style="background:#ffffff;border:1px solid #d8d0c3;border-top:7px solid #b84e2f;border-radius:8px;padding:20px;box-shadow:0 1px 2px rgba(30,36,40,.06);">
+          <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px;">
+            <span style="display:inline-grid;place-items:center;width:34px;height:34px;border-radius:50%;background:#b84e2f;color:white;font-weight:800;">3</span>
+            <div>
+              <h2 style="font-size:22px;margin:0;color:#291a15;letter-spacing:0;">CLI App Runner</h2>
+              <p style="margin:2px 0 0;color:#667074;font-size:13px;">Optimized for the command flow</p>
+            </div>
+          </div>
+
+          <div style="margin:16px 0 13px;">
+            <p style="margin:0 0 6px;font-size:12px;font-weight:800;color:#6b6258;text-transform:uppercase;letter-spacing:.08em;">Interface</p>
+            <pre style="white-space:pre-wrap;overflow:auto;margin:0;background:#1f2629;color:#f4efe6;border-radius:7px;padding:13px;font-size:13px;line-height:1.45;"><code>pub struct SearchCommand {
+    pub query: SearchQuery,
+    pub provider: ProviderSelection,
+}
+
+pub struct SearchCliApp;
+
+impl SearchCliApp {
+    pub fn from_env() -&gt; Self;
+    pub async fn run(
+        self,
+        command: SearchCommand,
+    ) -&gt; Result&lt;SearchResponse, SearchCliAppError&gt;;
+}</code></pre>
+          </div>
+
+          <div style="margin:16px 0 13px;">
+            <p style="margin:0 0 6px;font-size:12px;font-weight:800;color:#6b6258;text-transform:uppercase;letter-spacing:.08em;">Caller</p>
+            <pre style="white-space:pre-wrap;overflow:auto;margin:0;background:#f5f1ea;border:1px solid #ddd4c7;border-radius:7px;padding:13px;font-size:13px;line-height:1.45;"><code>let command = SearchCommand::from(args);
+
+match SearchCliApp::from_env().run(command).await {
+    Ok(response) =&gt; println!("{}", render_text(&amp;response)),
+    Err(error) =&gt; exit_with_error(error),
+}</code></pre>
+          </div>
+
+          <p style="margin:14px 0 7px;font-weight:800;color:#202629;">Hides</p>
+          <p style="margin:0;color:#4c5559;font-size:14px;">Provider construction and the call into <code style="background:#efe8dd;border:1px solid #ded4c5;border-radius:5px;padding:1px 4px;">SearchService::search</code>. <code style="background:#efe8dd;border:1px solid #ded4c5;border-radius:5px;padding:1px 4px;">main</code> becomes parse command, run app, render or exit.</p>
+
+          <p style="margin:14px 0 7px;font-weight:800;color:#202629;">Trade-off</p>
+          <p style="margin:0;color:#4c5559;font-size:14px;">Very clean for the CLI path, but it can blur composition with execution. It is less direct if other callers want a reusable <code style="background:#efe8dd;border:1px solid #ded4c5;border-radius:5px;padding:1px 4px;">SearchService</code>.</p>
+        </article>
+      </section>
+
+      <section style="margin-top:22px;display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:18px;">
+        <article style="background:#233036;color:#f4efe6;border-radius:8px;padding:20px;">
+          <h2 style="margin:0 0 12px;font-size:22px;letter-spacing:0;">Where They Diverge</h2>
+          <p style="margin:0 0 10px;color:#d8e1df;">The narrow factory keeps the existing architecture and just moves the noisy branch out of the reading path. The registry treats provider construction as a growing subsystem. The CLI app runner moves up a level and says the interface should be a command, not a service factory.</p>
+          <p style="margin:0;color:#d8e1df;">The key design choice is whether the caller wants a <code style="background:#314147;border:1px solid #4c5c62;border-radius:5px;padding:1px 4px;">SearchService</code> to keep using, or whether the caller just wants to execute one CLI search.</p>
+        </article>
+
+        <article style="background:#fff;border:1px solid #d8d0c3;border-radius:8px;padding:20px;">
+          <h2 style="margin:0 0 12px;font-size:22px;letter-spacing:0;">My Read</h2>
+          <p style="margin:0 0 10px;color:#4c5559;">For this repo right now, I would start with <strong>Option 1: Narrow Factory</strong>. It is deep enough to hide the mess, small enough to understand instantly, and it leaves the current layer boundaries intact.</p>
+          <p style="margin:0;color:#4c5559;">Option 2 is the future if providers/config sources grow. Option 3 is attractive if the binary should become an executable shell around a command object rather than a visible service orchestration flow.</p>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/.artifacts/plan/2026-04-25_13-50-32_provider-registry/PLAN.md
+++ b/.artifacts/plan/2026-04-25_13-50-32_provider-registry/PLAN.md
@@ -1,0 +1,336 @@
+---
+title: "Provider registry implementation plan"
+link: "provider-registry-plan"
+type: implementation_plan
+ontological_relations:
+  - relates_to: [[search-service-flow-visual]]
+  - relates_to: [[HARNESS]]
+tags: [plan, provider-registry, rust, search-cli, coding]
+uuid: "D81E9746-372F-41BA-9CAB-16A8CD55467D"
+created_at: "2026-04-25T13:50:32Z"
+parent_research: ".artifacts/interface-designs/search-service-flow-visual.html"
+git_commit_at_plan: "39c796e"
+---
+
+## Goal
+
+Implement a compile-time built-in provider registry/factory that replaces the inline provider construction `match` in `src/main.rs`, scales cleanly as more providers are added, and only registers providers whose required env config is present.
+
+Out of scope: runtime plugin providers, external provider discovery, config files, redesigning the transport trait, changing provider request/mapper behavior, and adding new search providers.
+
+## Scope & Assumptions
+
+IN scope:
+- Add a composition/bootstrap module that owns provider registration and `SearchService` construction.
+- Add a provider-neutral `ProviderId` separate from `cli::args::CliProvider`.
+- Add a registry that maps configured built-in providers to provider builder closures.
+- Make production registry creation include Brave only when `BraveConfig::from_env()` succeeds and Exa only when `ExaConfig::from_env()` succeeds.
+- Return a clear construction error when a selected provider is not registered because it is not configured.
+- Keep `main` responsible for CLI parsing, query construction, output rendering, and process exit.
+- Add focused tests for registry availability and `main` wiring boundaries where practical.
+
+OUT of scope:
+- `Box<dyn HttpClient>` or transport object erasure. Current `HttpClient` has generic methods and is not object-safe.
+- Shared erased config bags such as `ProviderConfig { api_key, base_url, extra }`.
+- Lazy provider setup that defers missing-key failures until `search`.
+- Runtime provider plugins or dynamic loading.
+- Reworking `SearchProvider`, `SearchService`, or provider DTO mapping.
+
+Assumptions:
+- `BraveConfig` and `ExaConfig` remain typed provider-owned config structs.
+- `BraveConfig::from_env()` requires `BRAVE_API_KEY`; `ExaConfig::from_env()` requires `EXA_API_KEY`.
+- `dotenvy::dotenv().ok()` remains in `main` before production registry creation.
+- The architecture boundary tests may be extended, but existing `domain`, `transport`, `providers`, and `app` restrictions must continue to pass.
+- The current untracked `.artifacts/interface-designs/` files are planning artifacts and should not affect source implementation.
+
+## Deliverables
+
+- `src/bootstrap/mod.rs`
+- `src/bootstrap/provider_registry.rs`
+- `src/main.rs` updates to call the registry/factory instead of inline provider construction
+- Optional focused unit tests inside `src/bootstrap/provider_registry.rs`
+- `tests/architecture_test.rs` updates if needed to document the new composition-layer boundary
+
+## Readiness
+
+Preconditions:
+- Current source tree includes `src/providers/brave/*`, `src/providers/exa/*`, `src/app/search_service.rs`, `src/domain/provider.rs`, and `src/transport/http.rs`.
+- The working tree may contain untracked planning artifacts under `.artifacts/interface-designs/`; execution should leave them intact.
+- `just check` remains the canonical final verification command.
+
+What must exist before starting:
+- Rust toolchain and dependencies already present.
+- No source files need to be generated outside the paths listed in this plan.
+
+## Milestones
+
+- M1: Bootstrap registry API and error contract
+- M2: Production provider registration from typed env config
+- M3: Main wiring migration and architecture guardrails
+- M4: Focused tests and final check path
+
+## Ticket Index
+
+<!-- TICKET_INDEX:START -->
+
+| Task | Title | Ticket |
+|---|---|---|
+| T001 | Add bootstrap module skeleton and ProviderId | [tickets/T001.md](tickets/T001.md) |
+| T002 | Define registry and construction error contract | [tickets/T002.md](tickets/T002.md) |
+| T003 | Add production registry that only includes configured providers | [tickets/T003.md](tickets/T003.md) |
+| T004 | Convert CliProvider to ProviderId at the binary edge | [tickets/T004.md](tickets/T004.md) |
+| T005 | Replace inline provider construction in main | [tickets/T005.md](tickets/T005.md) |
+| T006 | Extend architecture guardrails for the composition layer | [tickets/T006.md](tickets/T006.md) |
+| T007 | Add focused registry tests | [tickets/T007.md](tickets/T007.md) |
+| T008 | Run final local gate and update docs only if source references require it | [tickets/T008.md](tickets/T008.md) |
+
+<!-- TICKET_INDEX:END -->
+
+## Work Breakdown (Tasks)
+
+### T001: Add bootstrap module skeleton and ProviderId
+
+**Summary**: Create the composition module and provider-neutral selection type without wiring any providers yet.
+
+**Owner**: backend
+
+**Estimate**: 45m
+
+**Dependencies**: <none>
+
+**Target milestone**: M1
+
+**Acceptance test**: `cargo check` passes with `mod bootstrap;` declared and no provider behavior changed.
+
+**Files/modules touched**:
+- `src/main.rs`
+- `src/bootstrap/mod.rs`
+- `src/bootstrap/provider_registry.rs`
+
+**Steps**:
+1. Add `mod bootstrap;` near the other module declarations in `src/main.rs`.
+2. Create `src/bootstrap/mod.rs` with `pub mod provider_registry;`.
+3. Create `src/bootstrap/provider_registry.rs`.
+4. Define `#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)] pub enum ProviderId { Brave, Exa }`.
+5. Implement `Display` for `ProviderId` with lowercase labels `brave` and `exa`.
+6. Do not import `crate::cli` in `src/bootstrap/provider_registry.rs`.
+
+### T002: Define registry and construction error contract
+
+**Summary**: Add the provider registry type, provider builder alias, and construction errors used by production service creation.
+
+**Owner**: backend
+
+**Estimate**: 1h
+
+**Dependencies**: T001
+
+**Target milestone**: M1
+
+**Acceptance test**: Unit test constructs an empty registry and receives `ProviderUnavailable` when building `ProviderId::Brave`.
+
+**Files/modules touched**:
+- `src/bootstrap/provider_registry.rs`
+
+**Steps**:
+1. Import `std::collections::HashMap`, `crate::app::search_service::SearchService`, and `crate::domain::provider::SearchProvider`.
+2. Define `pub type ProviderBuilder = Box<dyn Fn() -> Box<dyn SearchProvider> + Send + Sync>;`.
+3. Define `pub struct ProviderRegistry { builders: HashMap<ProviderId, ProviderBuilder> }`.
+4. Add `pub fn empty() -> Self`.
+5. Add `pub fn register(&mut self, id: ProviderId, builder: ProviderBuilder)`.
+6. Add `pub fn available_providers(&self) -> Vec<ProviderId>` that returns stable sorted order `[Brave, Exa]` when present.
+7. Define `#[derive(Debug, thiserror::Error)] pub enum BuildSearchServiceError` with `ProviderUnavailable { provider: ProviderId, available: Vec<ProviderId> }`.
+8. Implement `pub fn build(&self, provider: ProviderId) -> Result<SearchService, BuildSearchServiceError>` that creates `SearchService::new(builder())` when registered.
+9. Add a unit test for empty registry unavailable behavior.
+
+### T003: Add production registry that only includes configured providers
+
+**Summary**: Implement env-backed production registration where missing provider keys mean the provider is omitted from the registry.
+
+**Owner**: backend
+
+**Estimate**: 1h
+
+**Dependencies**: T002
+
+**Target milestone**: M2
+
+**Acceptance test**: Unit test sets only `BRAVE_API_KEY` and confirms `production_from_env()` lists Brave but not Exa.
+
+**Files/modules touched**:
+- `src/bootstrap/provider_registry.rs`
+
+**Steps**:
+1. Import `BraveProvider`, `BraveConfig`, `ExaProvider`, `ExaConfig`, and `ReqwestHttpClient`.
+2. Add `pub fn production_from_env() -> Self`.
+3. In `production_from_env()`, call `BraveConfig::from_env()`. If it returns `Ok(config)`, register `ProviderId::Brave` with a closure that clones `config` and returns `Box::new(BraveProvider::new(ReqwestHttpClient::new(), config.clone()))`.
+4. In `production_from_env()`, call `ExaConfig::from_env()`. If it returns `Ok(config)`, register `ProviderId::Exa` with a closure that clones `config` and returns `Box::new(ExaProvider::new(ReqwestHttpClient::new(), config.clone()))`.
+5. If a config load returns `Err(std::env::VarError::NotPresent)`, do not register that provider.
+6. If a config load returns `Err(std::env::VarError::NotUnicode(_))`, do not register that provider for now; surface the same `ProviderUnavailable` if selected.
+7. Add tests that isolate env vars using a small test lock if needed because env is process-global.
+8. Ensure tests restore any modified `BRAVE_API_KEY` and `EXA_API_KEY` values.
+
+### T004: Convert CliProvider to ProviderId at the binary edge
+
+**Summary**: Add explicit conversion from CLI provider enum to bootstrap provider ID without making the registry depend on CLI types.
+
+**Owner**: backend
+
+**Estimate**: 30m
+
+**Dependencies**: T001
+
+**Target milestone**: M3
+
+**Acceptance test**: `cargo test cli::args::tests::test_cli_provider_parses_exa_and_defaults_to_brave` still passes.
+
+**Files/modules touched**:
+- `src/main.rs`
+
+**Steps**:
+1. Import `crate::bootstrap::provider_registry::ProviderId` in `src/main.rs`.
+2. Add `impl From<CliProvider> for ProviderId` in `src/main.rs`.
+3. Map `CliProvider::Brave` to `ProviderId::Brave`.
+4. Map `CliProvider::Exa` to `ProviderId::Exa`.
+5. Keep `src/bootstrap/provider_registry.rs` free of `crate::cli` imports.
+
+### T005: Replace inline provider construction in main
+
+**Summary**: Remove the duplicated provider construction `match` from `main` and delegate service construction to the production registry.
+
+**Owner**: backend
+
+**Estimate**: 45m
+
+**Dependencies**: T002,T003,T004
+
+**Target milestone**: M3
+
+**Acceptance test**: Running `cargo run -- "rust"` with no `BRAVE_API_KEY` prints a provider-unavailable/configuration message before any search request is attempted.
+
+**Files/modules touched**:
+- `src/main.rs`
+
+**Steps**:
+1. Remove direct imports of `SearchService`, `BraveProvider`, `BraveConfig`, `ExaProvider`, `ExaConfig`, and `ReqwestHttpClient` from `src/main.rs` if no longer used.
+2. Import `ProviderRegistry` from `src/bootstrap/provider_registry.rs`.
+3. Replace the inline `let service = match args.provider { ... };` block with:
+   - `let provider_id = ProviderId::from(args.provider);`
+   - `let registry = ProviderRegistry::production_from_env();`
+   - `let service = registry.build(provider_id).unwrap_or_else(|error| { eprintln!("{error}"); std::process::exit(1); });`
+4. Keep the existing `service.search(query).await` block unchanged.
+5. Ensure missing provider config fails during service construction, not during `service.search`.
+
+### T006: Extend architecture guardrails for the composition layer
+
+**Summary**: Document the new `bootstrap` layer in architecture tests so its intentionally broad dependencies do not weaken existing boundaries.
+
+**Owner**: backend
+
+**Estimate**: 45m
+
+**Dependencies**: T001,T005
+
+**Target milestone**: M3
+
+**Acceptance test**: `cargo test --test architecture_test` passes and includes a guard that `src/bootstrap` does not import `crate::cli`.
+
+**Files/modules touched**:
+- `tests/architecture_test.rs`
+
+**Steps**:
+1. Add a new architecture test named `test_bootstrap_does_not_import_cli`.
+2. Use the existing `check_dir_for_forbidden_patterns` helper against `src/bootstrap`.
+3. Forbid `use crate::cli::` in `src/bootstrap`.
+4. Leave existing tests for `domain`, `transport`, `providers`, `app`, and `render_text` unchanged.
+5. Do not forbid `bootstrap` from importing `app`, `providers`, `transport`, or `domain`; it is the composition layer.
+
+### T007: Add focused registry tests
+
+**Summary**: Add unit coverage for registration, available provider ordering, and successful service construction with fake providers.
+
+**Owner**: backend
+
+**Estimate**: 1h
+
+**Dependencies**: T002
+
+**Target milestone**: M4
+
+**Acceptance test**: `cargo test bootstrap::provider_registry` passes.
+
+**Files/modules touched**:
+- `src/bootstrap/provider_registry.rs`
+
+**Steps**:
+1. Add a `#[cfg(test)]` module in `src/bootstrap/provider_registry.rs`.
+2. Define a local `MockProvider` implementing `SearchProvider`.
+3. Add a test that registers `ProviderId::Brave`, verifies `available_providers()` returns `vec![ProviderId::Brave]`, and verifies `build(ProviderId::Brave)` succeeds.
+4. Add a test that registers both providers and verifies stable ordering is `vec![ProviderId::Brave, ProviderId::Exa]`.
+5. Keep env-dependent tests separated from pure registry tests.
+
+### T008: Run final local gate and update docs only if source references require it
+
+**Summary**: Run the repository check gate and only update developer docs if the new bootstrap layer makes existing maps inaccurate.
+
+**Owner**: backend
+
+**Estimate**: 45m
+
+**Dependencies**: T005,T006,T007
+
+**Target milestone**: M4
+
+**Acceptance test**: `just check` passes.
+
+**Files/modules touched**:
+- `HARNESS.md`
+- `docs/src/architecture.md`
+
+**Steps**:
+1. Run `cargo fmt`.
+2. Run `cargo test`.
+3. Run `cargo clippy -- -D warnings -W clippy::complexity -W clippy::cognitive_complexity`.
+4. Run `mdbook build`.
+5. Run `just check` as the final umbrella gate.
+6. If docs mention `src/main.rs` as directly wiring concrete providers, update only the affected lines in `docs/src/architecture.md`.
+7. If `HARNESS.md` source index or architecture boundary section is now inaccurate because `src/bootstrap` exists, update only those lines.
+
+## Risks & Mitigations
+
+- Risk: `HttpClient` is not object-safe because it has generic methods.
+  Mitigation: Do not put `Box<dyn HttpClient>` in the registry. Keep concrete `ReqwestHttpClient` inside provider builders.
+- Risk: Env-var tests are process-global and can be flaky under parallel test execution.
+  Mitigation: Prefer pure registry tests. If testing `production_from_env()`, guard env mutation with a test lock and restore variables.
+- Risk: Omitting unconfigured providers may make the default `brave` provider fail differently than before.
+  Mitigation: Use a clear `ProviderUnavailable` message that names the selected provider and lists configured providers.
+- Risk: A new composition layer can become a dumping ground.
+  Mitigation: Restrict it to provider registration and `SearchService` construction; keep query building and rendering in `main`/`cli`.
+- Risk: Architecture tests could accidentally forbid the new composition layer from doing its job.
+  Mitigation: Add only a `bootstrap` no-CLI guard; do not forbid imports of `app`, `providers`, `transport`, or `domain`.
+
+## Test Strategy
+
+- T002 adds one unit test for unavailable provider behavior.
+- T003 adds one env-backed availability test if it can be made deterministic.
+- T004 relies on the existing CLI parsing test as the acceptance proof.
+- T005 uses one manual CLI acceptance proof for missing-key behavior.
+- T006 adds one architecture boundary test for `src/bootstrap`.
+- T007 adds one focused registry unit test for successful construction and ordering.
+- T008 runs the full check gate.
+
+## References
+
+- `src/main.rs:55` current inline provider construction branch
+- `src/app/search_service.rs:6` `SearchService` owns `Box<dyn SearchProvider>`
+- `src/domain/provider.rs:19` `SearchProvider` trait object boundary
+- `src/transport/http.rs:6` generic `HttpClient` methods are not object-safe
+- `src/providers/brave/config.rs:8` Brave env config loading
+- `src/providers/exa/config.rs:8` Exa env config loading
+- `tests/architecture_test.rs:24` providers cannot import CLI or app
+- `.artifacts/interface-designs/search-service-flow-visual.html` visual comparison of interface options
+
+## Final Gate
+
+- **Output summary**: plan dir path, milestone count, ticket count
+- **Next step**: proceed to execute-phase with `.artifacts/plan/2026-04-25_13-50-32_provider-registry/PLAN.md`

--- a/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/INDEX.md
+++ b/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/INDEX.md
@@ -1,0 +1,20 @@
+---
+title: "Ticket Index"
+type: ticket_index
+parent_plan: "../PLAN.md"
+created_at: "2026-04-25T13:51:35Z"
+tags: [ticket, plan]
+---
+
+# Ticket Index
+
+| Task | Title | Ticket |
+|---|---|---|
+| T001 | Add bootstrap module skeleton and ProviderId | [T001](./T001.md) |
+| T002 | Define registry and construction error contract | [T002](./T002.md) |
+| T003 | Add production registry that only includes configured providers | [T003](./T003.md) |
+| T004 | Convert CliProvider to ProviderId at the binary edge | [T004](./T004.md) |
+| T005 | Replace inline provider construction in main | [T005](./T005.md) |
+| T006 | Extend architecture guardrails for the composition layer | [T006](./T006.md) |
+| T007 | Add focused registry tests | [T007](./T007.md) |
+| T008 | Run final local gate and update docs only if source references require it | [T008](./T008.md) |

--- a/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T001.md
+++ b/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T001.md
@@ -1,0 +1,35 @@
+---
+title: "T001: Add bootstrap module skeleton and ProviderId"
+type: plan_ticket
+task_id: "T001"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-25T13:51:35Z"
+tags: [ticket, plan]
+---
+
+# T001: Add bootstrap module skeleton and ProviderId
+
+**Summary**: Create the composition module and provider-neutral selection type without wiring any providers yet.
+
+**Owner**: backend
+
+**Estimate**: 45m
+
+**Dependencies**: <none>
+
+**Target milestone**: M1
+
+**Acceptance test**: `cargo check` passes with `mod bootstrap;` declared and no provider behavior changed.
+
+**Files/modules touched**:
+- `src/main.rs`
+- `src/bootstrap/mod.rs`
+- `src/bootstrap/provider_registry.rs`
+
+**Steps**:
+1. Add `mod bootstrap;` near the other module declarations in `src/main.rs`.
+2. Create `src/bootstrap/mod.rs` with `pub mod provider_registry;`.
+3. Create `src/bootstrap/provider_registry.rs`.
+4. Define `#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)] pub enum ProviderId { Brave, Exa }`.
+5. Implement `Display` for `ProviderId` with lowercase labels `brave` and `exa`.
+6. Do not import `crate::cli` in `src/bootstrap/provider_registry.rs`.

--- a/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T002.md
+++ b/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T002.md
@@ -1,0 +1,36 @@
+---
+title: "T002: Define registry and construction error contract"
+type: plan_ticket
+task_id: "T002"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-25T13:51:35Z"
+tags: [ticket, plan]
+---
+
+# T002: Define registry and construction error contract
+
+**Summary**: Add the provider registry type, provider builder alias, and construction errors used by production service creation.
+
+**Owner**: backend
+
+**Estimate**: 1h
+
+**Dependencies**: T001
+
+**Target milestone**: M1
+
+**Acceptance test**: Unit test constructs an empty registry and receives `ProviderUnavailable` when building `ProviderId::Brave`.
+
+**Files/modules touched**:
+- `src/bootstrap/provider_registry.rs`
+
+**Steps**:
+1. Import `std::collections::HashMap`, `crate::app::search_service::SearchService`, and `crate::domain::provider::SearchProvider`.
+2. Define `pub type ProviderBuilder = Box<dyn Fn() -> Box<dyn SearchProvider> + Send + Sync>;`.
+3. Define `pub struct ProviderRegistry { builders: HashMap<ProviderId, ProviderBuilder> }`.
+4. Add `pub fn empty() -> Self`.
+5. Add `pub fn register(&mut self, id: ProviderId, builder: ProviderBuilder)`.
+6. Add `pub fn available_providers(&self) -> Vec<ProviderId>` that returns stable sorted order `[Brave, Exa]` when present.
+7. Define `#[derive(Debug, thiserror::Error)] pub enum BuildSearchServiceError` with `ProviderUnavailable { provider: ProviderId, available: Vec<ProviderId> }`.
+8. Implement `pub fn build(&self, provider: ProviderId) -> Result<SearchService, BuildSearchServiceError>` that creates `SearchService::new(builder())` when registered.
+9. Add a unit test for empty registry unavailable behavior.

--- a/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T003.md
+++ b/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T003.md
@@ -1,0 +1,35 @@
+---
+title: "T003: Add production registry that only includes configured providers"
+type: plan_ticket
+task_id: "T003"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-25T13:51:35Z"
+tags: [ticket, plan]
+---
+
+# T003: Add production registry that only includes configured providers
+
+**Summary**: Implement env-backed production registration where missing provider keys mean the provider is omitted from the registry.
+
+**Owner**: backend
+
+**Estimate**: 1h
+
+**Dependencies**: T002
+
+**Target milestone**: M2
+
+**Acceptance test**: Unit test sets only `BRAVE_API_KEY` and confirms `production_from_env()` lists Brave but not Exa.
+
+**Files/modules touched**:
+- `src/bootstrap/provider_registry.rs`
+
+**Steps**:
+1. Import `BraveProvider`, `BraveConfig`, `ExaProvider`, `ExaConfig`, and `ReqwestHttpClient`.
+2. Add `pub fn production_from_env() -> Self`.
+3. In `production_from_env()`, call `BraveConfig::from_env()`. If it returns `Ok(config)`, register `ProviderId::Brave` with a closure that clones `config` and returns `Box::new(BraveProvider::new(ReqwestHttpClient::new(), config.clone()))`.
+4. In `production_from_env()`, call `ExaConfig::from_env()`. If it returns `Ok(config)`, register `ProviderId::Exa` with a closure that clones `config` and returns `Box::new(ExaProvider::new(ReqwestHttpClient::new(), config.clone()))`.
+5. If a config load returns `Err(std::env::VarError::NotPresent)`, do not register that provider.
+6. If a config load returns `Err(std::env::VarError::NotUnicode(_))`, do not register that provider for now; surface the same `ProviderUnavailable` if selected.
+7. Add tests that isolate env vars using a small test lock if needed because env is process-global.
+8. Ensure tests restore any modified `BRAVE_API_KEY` and `EXA_API_KEY` values.

--- a/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T004.md
+++ b/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T004.md
@@ -1,0 +1,32 @@
+---
+title: "T004: Convert CliProvider to ProviderId at the binary edge"
+type: plan_ticket
+task_id: "T004"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-25T13:51:35Z"
+tags: [ticket, plan]
+---
+
+# T004: Convert CliProvider to ProviderId at the binary edge
+
+**Summary**: Add explicit conversion from CLI provider enum to bootstrap provider ID without making the registry depend on CLI types.
+
+**Owner**: backend
+
+**Estimate**: 30m
+
+**Dependencies**: T001
+
+**Target milestone**: M3
+
+**Acceptance test**: `cargo test cli::args::tests::test_cli_provider_parses_exa_and_defaults_to_brave` still passes.
+
+**Files/modules touched**:
+- `src/main.rs`
+
+**Steps**:
+1. Import `crate::bootstrap::provider_registry::ProviderId` in `src/main.rs`.
+2. Add `impl From<CliProvider> for ProviderId` in `src/main.rs`.
+3. Map `CliProvider::Brave` to `ProviderId::Brave`.
+4. Map `CliProvider::Exa` to `ProviderId::Exa`.
+5. Keep `src/bootstrap/provider_registry.rs` free of `crate::cli` imports.

--- a/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T005.md
+++ b/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T005.md
@@ -1,0 +1,35 @@
+---
+title: "T005: Replace inline provider construction in main"
+type: plan_ticket
+task_id: "T005"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-25T13:51:35Z"
+tags: [ticket, plan]
+---
+
+# T005: Replace inline provider construction in main
+
+**Summary**: Remove the duplicated provider construction `match` from `main` and delegate service construction to the production registry.
+
+**Owner**: backend
+
+**Estimate**: 45m
+
+**Dependencies**: T002,T003,T004
+
+**Target milestone**: M3
+
+**Acceptance test**: Running `cargo run -- "rust"` with no `BRAVE_API_KEY` prints a provider-unavailable/configuration message before any search request is attempted.
+
+**Files/modules touched**:
+- `src/main.rs`
+
+**Steps**:
+1. Remove direct imports of `SearchService`, `BraveProvider`, `BraveConfig`, `ExaProvider`, `ExaConfig`, and `ReqwestHttpClient` from `src/main.rs` if no longer used.
+2. Import `ProviderRegistry` from `src/bootstrap/provider_registry.rs`.
+3. Replace the inline `let service = match args.provider { ... };` block with:
+   - `let provider_id = ProviderId::from(args.provider);`
+   - `let registry = ProviderRegistry::production_from_env();`
+   - `let service = registry.build(provider_id).unwrap_or_else(|error| { eprintln!("{error}"); std::process::exit(1); });`
+4. Keep the existing `service.search(query).await` block unchanged.
+5. Ensure missing provider config fails during service construction, not during `service.search`.

--- a/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T006.md
+++ b/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T006.md
@@ -1,0 +1,32 @@
+---
+title: "T006: Extend architecture guardrails for the composition layer"
+type: plan_ticket
+task_id: "T006"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-25T13:51:35Z"
+tags: [ticket, plan]
+---
+
+# T006: Extend architecture guardrails for the composition layer
+
+**Summary**: Document the new `bootstrap` layer in architecture tests so its intentionally broad dependencies do not weaken existing boundaries.
+
+**Owner**: backend
+
+**Estimate**: 45m
+
+**Dependencies**: T001,T005
+
+**Target milestone**: M3
+
+**Acceptance test**: `cargo test --test architecture_test` passes and includes a guard that `src/bootstrap` does not import `crate::cli`.
+
+**Files/modules touched**:
+- `tests/architecture_test.rs`
+
+**Steps**:
+1. Add a new architecture test named `test_bootstrap_does_not_import_cli`.
+2. Use the existing `check_dir_for_forbidden_patterns` helper against `src/bootstrap`.
+3. Forbid `use crate::cli::` in `src/bootstrap`.
+4. Leave existing tests for `domain`, `transport`, `providers`, `app`, and `render_text` unchanged.
+5. Do not forbid `bootstrap` from importing `app`, `providers`, `transport`, or `domain`; it is the composition layer.

--- a/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T007.md
+++ b/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T007.md
@@ -1,0 +1,32 @@
+---
+title: "T007: Add focused registry tests"
+type: plan_ticket
+task_id: "T007"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-25T13:51:35Z"
+tags: [ticket, plan]
+---
+
+# T007: Add focused registry tests
+
+**Summary**: Add unit coverage for registration, available provider ordering, and successful service construction with fake providers.
+
+**Owner**: backend
+
+**Estimate**: 1h
+
+**Dependencies**: T002
+
+**Target milestone**: M4
+
+**Acceptance test**: `cargo test bootstrap::provider_registry` passes.
+
+**Files/modules touched**:
+- `src/bootstrap/provider_registry.rs`
+
+**Steps**:
+1. Add a `#[cfg(test)]` module in `src/bootstrap/provider_registry.rs`.
+2. Define a local `MockProvider` implementing `SearchProvider`.
+3. Add a test that registers `ProviderId::Brave`, verifies `available_providers()` returns `vec![ProviderId::Brave]`, and verifies `build(ProviderId::Brave)` succeeds.
+4. Add a test that registers both providers and verifies stable ordering is `vec![ProviderId::Brave, ProviderId::Exa]`.
+5. Keep env-dependent tests separated from pure registry tests.

--- a/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T008.md
+++ b/.artifacts/plan/2026-04-25_13-50-32_provider-registry/tickets/T008.md
@@ -1,0 +1,74 @@
+---
+title: "T008: Run final local gate and update docs only if source references require it"
+type: plan_ticket
+task_id: "T008"
+parent_plan: "../PLAN.md"
+created_at: "2026-04-25T13:51:35Z"
+tags: [ticket, plan]
+---
+
+# T008: Run final local gate and update docs only if source references require it
+
+**Summary**: Run the repository check gate and only update developer docs if the new bootstrap layer makes existing maps inaccurate.
+
+**Owner**: backend
+
+**Estimate**: 45m
+
+**Dependencies**: T005,T006,T007
+
+**Target milestone**: M4
+
+**Acceptance test**: `just check` passes.
+
+**Files/modules touched**:
+- `HARNESS.md`
+- `docs/src/architecture.md`
+
+**Steps**:
+1. Run `cargo fmt`.
+2. Run `cargo test`.
+3. Run `cargo clippy -- -D warnings -W clippy::complexity -W clippy::cognitive_complexity`.
+4. Run `mdbook build`.
+5. Run `just check` as the final umbrella gate.
+6. If docs mention `src/main.rs` as directly wiring concrete providers, update only the affected lines in `docs/src/architecture.md`.
+7. If `HARNESS.md` source index or architecture boundary section is now inaccurate because `src/bootstrap` exists, update only those lines.
+
+## Risks & Mitigations
+
+- Risk: `HttpClient` is not object-safe because it has generic methods.
+  Mitigation: Do not put `Box<dyn HttpClient>` in the registry. Keep concrete `ReqwestHttpClient` inside provider builders.
+- Risk: Env-var tests are process-global and can be flaky under parallel test execution.
+  Mitigation: Prefer pure registry tests. If testing `production_from_env()`, guard env mutation with a test lock and restore variables.
+- Risk: Omitting unconfigured providers may make the default `brave` provider fail differently than before.
+  Mitigation: Use a clear `ProviderUnavailable` message that names the selected provider and lists configured providers.
+- Risk: A new composition layer can become a dumping ground.
+  Mitigation: Restrict it to provider registration and `SearchService` construction; keep query building and rendering in `main`/`cli`.
+- Risk: Architecture tests could accidentally forbid the new composition layer from doing its job.
+  Mitigation: Add only a `bootstrap` no-CLI guard; do not forbid imports of `app`, `providers`, `transport`, or `domain`.
+
+## Test Strategy
+
+- T002 adds one unit test for unavailable provider behavior.
+- T003 adds one env-backed availability test if it can be made deterministic.
+- T004 relies on the existing CLI parsing test as the acceptance proof.
+- T005 uses one manual CLI acceptance proof for missing-key behavior.
+- T006 adds one architecture boundary test for `src/bootstrap`.
+- T007 adds one focused registry unit test for successful construction and ordering.
+- T008 runs the full check gate.
+
+## References
+
+- `src/main.rs:55` current inline provider construction branch
+- `src/app/search_service.rs:6` `SearchService` owns `Box<dyn SearchProvider>`
+- `src/domain/provider.rs:19` `SearchProvider` trait object boundary
+- `src/transport/http.rs:6` generic `HttpClient` methods are not object-safe
+- `src/providers/brave/config.rs:8` Brave env config loading
+- `src/providers/exa/config.rs:8` Exa env config loading
+- `tests/architecture_test.rs:24` providers cannot import CLI or app
+- `.artifacts/interface-designs/search-service-flow-visual.html` visual comparison of interface options
+
+## Final Gate
+
+- **Output summary**: plan dir path, milestone count, ticket count
+- **Next step**: proceed to execute-phase with `.artifacts/plan/2026-04-25_13-50-32_provider-registry/PLAN.md`

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -37,6 +37,7 @@ There is no Makefile, npm script, or other local entrypoint. `just check` is the
 | transport-isolation | `src/transport/` | `crate::providers`, `crate::cli`, `crate::app` | `tests/architecture_test.rs` |
 | provider-isolation | `src/providers/` | `crate::cli`, `crate::app` | `tests/architecture_test.rs` |
 | app-isolation | `src/app/` | `crate::cli` | `tests/architecture_test.rs` |
+| bootstrap-isolation | `src/bootstrap/` | `crate::cli` | `tests/architecture_test.rs` |
 | render_text-isolation | all except `src/cli/` | `render_text` | `tests/architecture_test.rs` |
 
 Architecture boundary tests run as part of `cargo test`.
@@ -47,12 +48,12 @@ No structural rule engine is currently configured (no ast-grep, semgrep, or cust
 ### Layer 4: Behavioral Verification
 | Test Suite | Command | Location | Notes |
 |------------|---------|----------|-------|
-| Unit tests (inline) | `cargo test` | `src/**/*.rs` under `#[cfg(test)]` | 7 tests across 4 modules |
+| Unit tests (inline) | `cargo test` | `src/**/*.rs` under `#[cfg(test)]` | 22 tests across source modules |
 | Mapper tests | `cargo test` | `src/providers/brave/mapper.rs` | 4 tests: web, news, images, videos DTO→domain mapping |
 | Provider tests | `cargo test` | `src/providers/brave/client.rs` | 1 mock-HTTP test for `BraveProvider::search` |
 | App-layer tests | `cargo test` | `src/app/search_service.rs` | 1 mock-provider test for `SearchService` delegation |
 | Output tests | `cargo test` | `src/cli/output.rs` | 1 text-rendering test with mixed result types |
-| Architecture tests | `cargo test` | `tests/architecture_test.rs` | 5 source-scan tests enforcing layer boundaries |
+| Architecture tests | `cargo test` | `tests/architecture_test.rs` | 6 source-scan tests enforcing layer boundaries |
 
 No snapshot, golden, or integration test suites exist.
 
@@ -108,6 +109,7 @@ Ordered list of checks as executed by the canonical entry point:
 | `docs/` | mdBook source: intro, architecture, quickstart |
 | `book.toml` | mdBook configuration |
 | `Cargo.toml` | Project manifest, dependencies, edition 2024 |
+| `src/bootstrap/provider_registry.rs` | Built-in provider registry and service construction tests |
 | `src/providers/brave/mapper.rs` | 4 unit tests for DTO→domain mapping |
 | `src/providers/brave/client.rs` | 1 mock-HTTP unit test for Brave provider |
 | `src/app/search_service.rs` | 1 mock-provider unit test for SearchService |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Design principle
 
-The codebase is split into four strictly ordered layers. **No layer may import from a layer above it.** This prevents the CLI from leaking into the domain and keeps providers interchangeable.
+The codebase is split into four strictly ordered runtime layers plus a narrow bootstrap composition layer. **No runtime layer may import from a layer above it.** This prevents the CLI from leaking into the domain and keeps providers interchangeable.
 
 ```
 cli (top)
@@ -14,6 +14,8 @@ providers
 transport
   ↑
 domain (bottom)
+
+bootstrap composes app + providers + transport at startup
 ```
 
 ## Full request lifecycle
@@ -24,7 +26,8 @@ domain (bottom)
 
 2. src/main.rs
    └── CliArgs::parse() produces CliArgs { query, provider, search_type, limit, ... }
-   └── selects BraveProvider or ExaProvider
+   └── converts CliProvider to ProviderId
+   └── asks the bootstrap ProviderRegistry to build SearchService
    └── maps CliArgs → SearchQuery
 
 3. src/app/search_service.rs
@@ -162,10 +165,10 @@ Unsupported Exa inputs are rejected at runtime instead of being ignored: `Images
 
 ## Runtime provider selection
 
-`main.rs` remains the only place that chooses a concrete provider. `SearchQuery`, `SearchResponse`, `SearchProvider`, and `SearchService` stay unchanged.
+`main.rs` remains the binary edge that chooses the requested provider ID. Concrete provider construction lives in `src/bootstrap/provider_registry.rs`, where typed provider config, HTTP transport, provider clients, and `SearchService` are composed.
 
-- `--provider brave` loads `BraveConfig` and constructs `BraveProvider`
-- `--provider exa` loads `ExaConfig` and constructs `ExaProvider`
+- `--provider brave` maps to `ProviderId::Brave`; the registry includes it only when `BRAVE_API_KEY` is configured
+- `--provider exa` maps to `ProviderId::Exa`; the registry includes it only when `EXA_API_KEY` is configured
 - omitting `--provider` still selects Brave
 
 ## Architecture enforcement
@@ -178,6 +181,7 @@ The rules are verified by `tests/architecture_test.rs`. These tests scan source 
 | `src/transport/` | `crate::providers::`, `crate::cli::`, `crate::app::` |
 | `src/providers/` | `crate::cli::`, `crate::app::` |
 | `src/app/` | `crate::cli::` |
+| `src/bootstrap/` | `crate::cli::` |
 | Any layer except `src/cli/` | `render_text` |
 
 Run them with the rest of the suite:

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1,0 +1,1 @@
+pub mod provider_registry;

--- a/src/bootstrap/provider_registry.rs
+++ b/src/bootstrap/provider_registry.rs
@@ -88,13 +88,12 @@ impl ProviderRegistry {
     }
 
     pub fn build(&self, provider: ProviderId) -> Result<SearchService, BuildSearchServiceError> {
-        let builder =
-            self.builders
-                .get(&provider)
-                .ok_or_else(|| BuildSearchServiceError::ProviderUnavailable {
-                    provider,
-                    available: self.available_providers(),
-                })?;
+        let builder = self.builders.get(&provider).ok_or_else(|| {
+            BuildSearchServiceError::ProviderUnavailable {
+                provider,
+                available: self.available_providers(),
+            }
+        })?;
 
         Ok(SearchService::new(builder()))
     }

--- a/src/bootstrap/provider_registry.rs
+++ b/src/bootstrap/provider_registry.rs
@@ -1,0 +1,16 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProviderId {
+    Brave,
+    Exa,
+}
+
+impl fmt::Display for ProviderId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProviderId::Brave => formatter.write_str("brave"),
+            ProviderId::Exa => formatter.write_str("exa"),
+        }
+    }
+}

--- a/src/bootstrap/provider_registry.rs
+++ b/src/bootstrap/provider_registry.rs
@@ -3,6 +3,11 @@ use std::fmt;
 
 use crate::app::search_service::SearchService;
 use crate::domain::provider::SearchProvider;
+use crate::providers::brave::client::BraveProvider;
+use crate::providers::brave::config::BraveConfig;
+use crate::providers::exa::client::ExaProvider;
+use crate::providers::exa::config::ExaConfig;
+use crate::transport::http::ReqwestHttpClient;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ProviderId {
@@ -41,6 +46,36 @@ impl ProviderRegistry {
         }
     }
 
+    pub fn production_from_env() -> Self {
+        let mut registry = Self::empty();
+
+        match BraveConfig::from_env() {
+            Ok(config) => {
+                registry.register(
+                    ProviderId::Brave,
+                    Box::new(move || {
+                        Box::new(BraveProvider::new(ReqwestHttpClient::new(), config.clone()))
+                    }),
+                );
+            }
+            Err(std::env::VarError::NotPresent | std::env::VarError::NotUnicode(_)) => {}
+        }
+
+        match ExaConfig::from_env() {
+            Ok(config) => {
+                registry.register(
+                    ProviderId::Exa,
+                    Box::new(move || {
+                        Box::new(ExaProvider::new(ReqwestHttpClient::new(), config.clone()))
+                    }),
+                );
+            }
+            Err(std::env::VarError::NotPresent | std::env::VarError::NotUnicode(_)) => {}
+        }
+
+        registry
+    }
+
     pub fn register(&mut self, id: ProviderId, builder: ProviderBuilder) {
         self.builders.insert(id, builder);
     }
@@ -68,6 +103,24 @@ impl ProviderRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn restore_env_var(name: &str, value: Option<OsString>) {
+        match value {
+            Some(value) => unsafe {
+                std::env::set_var(name, value);
+            },
+            None => unsafe {
+                std::env::remove_var(name);
+            },
+        }
+    }
 
     #[test]
     fn empty_registry_reports_provider_unavailable() {
@@ -83,5 +136,24 @@ mod tests {
             }
             Ok(_) => panic!("expected ProviderUnavailable error"),
         }
+    }
+
+    #[test]
+    fn production_registry_only_includes_configured_providers() {
+        let _guard = env_lock().lock().unwrap();
+        let original_brave = std::env::var_os("BRAVE_API_KEY");
+        let original_exa = std::env::var_os("EXA_API_KEY");
+
+        unsafe {
+            std::env::set_var("BRAVE_API_KEY", "test-brave-key");
+            std::env::remove_var("EXA_API_KEY");
+        }
+
+        let registry = ProviderRegistry::production_from_env();
+
+        restore_env_var("BRAVE_API_KEY", original_brave);
+        restore_env_var("EXA_API_KEY", original_exa);
+
+        assert_eq!(registry.available_providers(), vec![ProviderId::Brave]);
     }
 }

--- a/src/bootstrap/provider_registry.rs
+++ b/src/bootstrap/provider_registry.rs
@@ -1,4 +1,8 @@
+use std::collections::HashMap;
 use std::fmt;
+
+use crate::app::search_service::SearchService;
+use crate::domain::provider::SearchProvider;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ProviderId {
@@ -11,6 +15,73 @@ impl fmt::Display for ProviderId {
         match self {
             ProviderId::Brave => formatter.write_str("brave"),
             ProviderId::Exa => formatter.write_str("exa"),
+        }
+    }
+}
+
+pub type ProviderBuilder = Box<dyn Fn() -> Box<dyn SearchProvider> + Send + Sync>;
+
+pub struct ProviderRegistry {
+    builders: HashMap<ProviderId, ProviderBuilder>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BuildSearchServiceError {
+    #[error("provider `{provider}` is unavailable; configured providers: {available:?}")]
+    ProviderUnavailable {
+        provider: ProviderId,
+        available: Vec<ProviderId>,
+    },
+}
+
+impl ProviderRegistry {
+    pub fn empty() -> Self {
+        Self {
+            builders: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, id: ProviderId, builder: ProviderBuilder) {
+        self.builders.insert(id, builder);
+    }
+
+    pub fn available_providers(&self) -> Vec<ProviderId> {
+        [ProviderId::Brave, ProviderId::Exa]
+            .into_iter()
+            .filter(|id| self.builders.contains_key(id))
+            .collect()
+    }
+
+    pub fn build(&self, provider: ProviderId) -> Result<SearchService, BuildSearchServiceError> {
+        let builder =
+            self.builders
+                .get(&provider)
+                .ok_or_else(|| BuildSearchServiceError::ProviderUnavailable {
+                    provider,
+                    available: self.available_providers(),
+                })?;
+
+        Ok(SearchService::new(builder()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_registry_reports_provider_unavailable() {
+        let registry = ProviderRegistry::empty();
+
+        match registry.build(ProviderId::Brave) {
+            Err(BuildSearchServiceError::ProviderUnavailable {
+                provider,
+                available,
+            }) => {
+                assert_eq!(provider, ProviderId::Brave);
+                assert!(available.is_empty());
+            }
+            Ok(_) => panic!("expected ProviderUnavailable error"),
         }
     }
 }

--- a/src/bootstrap/provider_registry.rs
+++ b/src/bootstrap/provider_registry.rs
@@ -103,8 +103,44 @@ impl ProviderRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::error::SearchError;
+    use crate::domain::provider::ProviderCapabilities;
+    use crate::domain::query::SearchQuery;
+    use crate::domain::result::SearchResponse;
+    use async_trait::async_trait;
     use std::ffi::OsString;
     use std::sync::{Mutex, OnceLock};
+
+    struct MockProvider;
+
+    #[async_trait]
+    impl SearchProvider for MockProvider {
+        fn id(&self) -> String {
+            "mock".to_string()
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                web: true,
+                news: true,
+                images: false,
+                videos: false,
+                pagination: false,
+                safe_search: false,
+                time_range_filter: false,
+            }
+        }
+
+        async fn search(&self, _query: &SearchQuery) -> Result<SearchResponse, SearchError> {
+            Ok(SearchResponse {
+                query: "mock".to_string(),
+                provider: "mock".to_string(),
+                results: vec![],
+                total_estimated: None,
+                next_page: None,
+            })
+        }
+    }
 
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -155,5 +191,26 @@ mod tests {
         restore_env_var("EXA_API_KEY", original_exa);
 
         assert_eq!(registry.available_providers(), vec![ProviderId::Brave]);
+    }
+
+    #[test]
+    fn registered_provider_is_available_and_builds_service() {
+        let mut registry = ProviderRegistry::empty();
+        registry.register(ProviderId::Brave, Box::new(|| Box::new(MockProvider)));
+
+        assert_eq!(registry.available_providers(), vec![ProviderId::Brave]);
+        assert!(registry.build(ProviderId::Brave).is_ok());
+    }
+
+    #[test]
+    fn available_providers_are_returned_in_stable_order() {
+        let mut registry = ProviderRegistry::empty();
+        registry.register(ProviderId::Exa, Box::new(|| Box::new(MockProvider)));
+        registry.register(ProviderId::Brave, Box::new(|| Box::new(MockProvider)));
+
+        assert_eq!(
+            registry.available_providers(),
+            vec![ProviderId::Brave, ProviderId::Exa]
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,17 +5,11 @@ mod domain;
 mod providers;
 mod transport;
 
-use app::search_service::SearchService;
-use bootstrap::provider_registry::ProviderId;
+use bootstrap::provider_registry::{ProviderId, ProviderRegistry};
 use clap::Parser;
 use cli::args::{CliArgs, CliProvider};
 use cli::output::render_text;
 use domain::query::SearchQuery;
-use providers::brave::client::BraveProvider;
-use providers::brave::config::BraveConfig;
-use providers::exa::client::ExaProvider;
-use providers::exa::config::ExaConfig;
-use transport::http::ReqwestHttpClient;
 
 impl From<CliProvider> for ProviderId {
     fn from(provider: CliProvider) -> Self {
@@ -63,30 +57,12 @@ async fn main() {
         time_range: None,
     };
 
-    let service = match args.provider {
-        CliProvider::Brave => {
-            let config = match BraveConfig::from_env() {
-                Ok(config) => config,
-                Err(error) => {
-                    eprintln!("Failed to load Brave config: {}", error);
-                    std::process::exit(1);
-                }
-            };
-            let provider = BraveProvider::new(ReqwestHttpClient::new(), config);
-            SearchService::new(Box::new(provider))
-        }
-        CliProvider::Exa => {
-            let config = match ExaConfig::from_env() {
-                Ok(config) => config,
-                Err(error) => {
-                    eprintln!("Failed to load Exa config: {}", error);
-                    std::process::exit(1);
-                }
-            };
-            let provider = ExaProvider::new(ReqwestHttpClient::new(), config);
-            SearchService::new(Box::new(provider))
-        }
-    };
+    let provider_id = ProviderId::from(args.provider);
+    let registry = ProviderRegistry::production_from_env();
+    let service = registry.build(provider_id).unwrap_or_else(|error| {
+        eprintln!("{error}");
+        std::process::exit(1);
+    });
 
     match service.search(query).await {
         Ok(response) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod bootstrap;
 mod cli;
 mod domain;
 mod providers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod providers;
 mod transport;
 
 use app::search_service::SearchService;
+use bootstrap::provider_registry::ProviderId;
 use clap::Parser;
 use cli::args::{CliArgs, CliProvider};
 use cli::output::render_text;
@@ -15,6 +16,15 @@ use providers::brave::config::BraveConfig;
 use providers::exa::client::ExaProvider;
 use providers::exa::config::ExaConfig;
 use transport::http::ReqwestHttpClient;
+
+impl From<CliProvider> for ProviderId {
+    fn from(provider: CliProvider) -> Self {
+        match provider {
+            CliProvider::Brave => ProviderId::Brave,
+            CliProvider::Exa => ProviderId::Exa,
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() {

--- a/tests/architecture_test.rs
+++ b/tests/architecture_test.rs
@@ -35,6 +35,12 @@ fn test_app_does_not_import_cli() {
 }
 
 #[test]
+fn test_bootstrap_does_not_import_cli() {
+    let forbidden = ["use crate::cli::"];
+    check_dir_for_forbidden_patterns("src/bootstrap", &forbidden);
+}
+
+#[test]
 fn test_render_text_only_called_from_cli() {
     let forbidden_dirs = ["src/domain", "src/transport", "src/providers", "src/app"];
     for dir in &forbidden_dirs {


### PR DESCRIPTION
## Summary

- Add a bootstrap provider registry that owns built-in provider registration and `SearchService` construction.
- Move Brave/Exa construction out of `main.rs` behind a provider-neutral `ProviderId` and registry lookup.
- Register production providers only when their required env config is present.
- Add registry tests, a bootstrap architecture guard, and update architecture/harness docs for the new layer.

## Validation

- `cargo fmt`
- `cargo test` (22 unit tests + 6 architecture tests)
- `cargo clippy -- -D warnings -W clippy::complexity -W clippy::cognitive_complexity`
- `mdbook build`
- `just check`

Note: `mdbook` was missing locally, so `mdbook v0.5.2` was installed via `cargo install mdbook --locked` before rerunning the docs and umbrella gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Application startup now validates provider configuration and loads only providers with configured credentials, improving startup reliability and enabling early detection of missing API keys.
  * Error messages now display the list of available configured providers when a requested provider cannot be selected or is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->