### PR TITLE
feat: add structured logging with tracing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,12 @@
 - `justfile` — canonical local check gate
 - `Cargo.toml` — dependencies and edition 2024
 
+## Observability
+- Structured logging is provided by `tracing` (with `tracing-subscriber` formatting).
+- Log output is written to **stderr** so stdout remains clean for CLI results.
+- Control verbosity via the `RUST_LOG` environment variable (e.g. `RUST_LOG=debug`).
+- Key spans: `main` (startup), `SearchService::search` (orchestration), `BraveProvider::search` / `ExaProvider::search` (provider adapters), `ReqwestHttpClient::{get_json,post_json}` (transport).
+
 ## Change Guardrails
 - Run `just check` before committing.
 - Keep domain types provider-agnostic; add provider-specific logic in `src/providers/`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +717,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +762,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +808,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -943,6 +976,23 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1156,6 +1206,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1265,8 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1309,6 +1370,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1434,7 +1504,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1444,6 +1526,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1493,6 +1605,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 dotenvy = "0.15"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/app/search_service.rs
+++ b/src/app/search_service.rs
@@ -12,8 +12,14 @@ impl SearchService {
         Self { provider }
     }
 
+    #[tracing::instrument(skip(self), fields(query = %query.text, provider = %self.provider.id()))]
     pub async fn search(&self, query: SearchQuery) -> Result<SearchResponse, SearchError> {
-        self.provider.search(&query).await
+        tracing::debug!("delegating search to provider");
+        let result = self.provider.search(&query).await;
+        if let Err(ref e) = result {
+            tracing::warn!(error = %e, "provider search returned error");
+        }
+        result
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use clap::Parser;
 use cli::args::{CliArgs, CliProvider};
 use cli::output::render_text;
 use domain::query::SearchQuery;
+use tracing_subscriber::EnvFilter;
 
 impl From<CliProvider> for ProviderId {
     fn from(provider: CliProvider) -> Self {
@@ -22,6 +23,11 @@ impl From<CliProvider> for ProviderId {
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .init();
+
     dotenvy::dotenv().ok();
 
     let args = CliArgs::parse();
@@ -58,17 +64,22 @@ async fn main() {
     };
 
     let provider_id = ProviderId::from(args.provider);
+    tracing::info!(provider = %provider_id, query = %query.text, "initializing search service");
+
     let registry = ProviderRegistry::production_from_env();
     let service = registry.build(provider_id).unwrap_or_else(|error| {
+        tracing::error!(%error, "failed to build provider");
         eprintln!("{error}");
         std::process::exit(1);
     });
 
     match service.search(query).await {
         Ok(response) => {
+            tracing::info!(result_count = response.results.len(), total_estimated = ?response.total_estimated, "search completed");
             println!("{}", render_text(&response));
         }
         Err(e) => {
+            tracing::error!(error = %e, "search failed");
             eprintln!("Search failed: {}", e);
             std::process::exit(1);
         }

--- a/src/providers/brave/client.rs
+++ b/src/providers/brave/client.rs
@@ -38,6 +38,7 @@ impl<C: HttpClient> SearchProvider for BraveProvider<C> {
         }
     }
 
+    #[tracing::instrument(skip(self), fields(query = %query.text, search_type = ?query.search_type))]
     async fn search(&self, query: &SearchQuery) -> Result<SearchResponse, SearchError> {
         let endpoint = match query.search_type {
             SearchType::Web => "web/search",

--- a/src/providers/exa/client.rs
+++ b/src/providers/exa/client.rs
@@ -105,6 +105,7 @@ impl<C: HttpClient> SearchProvider for ExaProvider<C> {
         }
     }
 
+    #[tracing::instrument(skip(self), fields(query = %query.text, search_type = ?query.search_type))]
     async fn search(&self, query: &SearchQuery) -> Result<SearchResponse, SearchError> {
         let request = self.build_request(query)?;
         let response: ExaSearchResponse = self

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -66,6 +66,7 @@ impl ReqwestHttpClient {
 
 #[async_trait]
 impl HttpClient for ReqwestHttpClient {
+    #[tracing::instrument(skip(self), fields(url = %url))]
     async fn get_json<T>(
         &self,
         url: &str,
@@ -85,9 +86,11 @@ impl HttpClient for ReqwestHttpClient {
             .await
             .map_err(|e| SearchError::Transport(e.to_string()))?;
 
+        tracing::debug!(status = %resp.status(), "received HTTP response");
         Self::decode_response(resp).await
     }
 
+    #[tracing::instrument(skip(self, body), fields(url = %url))]
     async fn post_json<T, B>(
         &self,
         url: &str,
@@ -108,6 +111,7 @@ impl HttpClient for ReqwestHttpClient {
             .await
             .map_err(|e| SearchError::Transport(e.to_string()))?;
 
+        tracing::debug!(status = %resp.status(), "received HTTP response");
         Self::decode_response(resp).await
     }
 }

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -66,7 +66,7 @@ impl ReqwestHttpClient {
 
 #[async_trait]
 impl HttpClient for ReqwestHttpClient {
-    #[tracing::instrument(skip(self), fields(url = %url))]
+    #[tracing::instrument(skip(self, headers), fields(url = %url))]
     async fn get_json<T>(
         &self,
         url: &str,
@@ -90,7 +90,7 @@ impl HttpClient for ReqwestHttpClient {
         Self::decode_response(resp).await
     }
 
-    #[tracing::instrument(skip(self, body), fields(url = %url))]
+    #[tracing::instrument(skip(self, headers, body), fields(url = %url))]
     async fn post_json<T, B>(
         &self,
         url: &str,


### PR DESCRIPTION
## Summary
Adds `tracing` and `tracing-subscriber` for structured, environment-filtered logging across the CLI, application layer, transport, and provider adapters.

## Changes
- Initialized `tracing_subscriber::fmt` in `main.rs` with `EnvFilter` (controlled via `RUST_LOG`)
- Logs are written to **stderr** so stdout remains clean for CLI results
- Added `#[tracing::instrument]` spans and log events in:
  - `SearchService::search` (orchestration layer)
  - `BraveProvider::search` and `ExaProvider::search` (provider adapters)
  - `ReqwestHttpClient::get_json` and `post_json` (transport layer)
- Updated `AGENTS.md` with an Observability section documenting the logging setup

## Verification
- `just check` passes (fmt, clippy, 28 tests, mdBook docs build)
- No architecture boundary violations introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an observability guide describing structured logging, log output to stderr, runtime verbosity control via RUST_LOG, and span coverage for startup, search orchestration, provider calls, and HTTP transport.

* **Chores**
  * Enabled structured diagnostic logging across the app and CLI so startup, successful searches, provider errors, and HTTP request/response statuses are emitted for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->