### PR TITLE
Add all-enabled provider fan-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![sophon](docs/sophon.png)
 
-A provider-agnostic Rust CLI that queries Brave Search or Exa and prints normalized text results.
+A provider-agnostic Rust CLI that queries Brave Search, Exa, or every environment-enabled provider and prints normalized text results.
 
 ## Install
 
@@ -21,6 +21,9 @@ cargo run -- "rust programming"
 # Choose a provider explicitly
 cargo run -- "rust programming" --provider brave
 cargo run -- "rust programming" --provider exa
+
+# Query every provider enabled by environment variables
+cargo run -- "rust async trait" --provider all
 
 # Show package info
 cargo run -- --about
@@ -41,7 +44,7 @@ echo "BRAVE_API_KEY=your_key_here" > .env
 echo "EXA_API_KEY=your_key_here" > .env
 ```
 
-You can also export the variables directly in your shell instead of using `.env`.
+You can also export the variables directly in your shell instead of using `.env`. `--provider all` queries every provider enabled by the current environment; for example, set both `BRAVE_API_KEY` and `EXA_API_KEY` to fan out to both providers.
 
 ## Example usage
 
@@ -54,12 +57,16 @@ sophon-cli "open source ai" --provider brave --search-type news --limit 3
 
 # Exa search
 sophon-cli "vector database benchmarks" --provider exa --limit 5
+
+# All configured providers, with per-provider successes and failures
+sophon-cli "rust async trait" --provider all
 ```
 
 ## Supported providers
 
 - `brave` for web, news, images, and video search
 - `exa` for Exa search results mapped into the shared domain model
+- `all` to query every configured provider in stable order and print per-provider failures when one provider rejects or fails a request
 
 ## Docs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,13 +38,14 @@ bootstrap composes app + providers + transport at startup
 
 2. src/main.rs
    └── CliArgs::parse() produces CliArgs { query, provider, search_type, limit, ... }
-   └── converts CliProvider to ProviderId
-   └── asks the bootstrap ProviderRegistry to build SearchService
    └── maps CliArgs → SearchQuery
+   └── for `brave` or `exa`, asks ProviderRegistry::build(provider) for SearchService
+   └── for `all`, asks ProviderRegistry::build_all_enabled() for FanoutSearchService
 
-3. src/app/search_service.rs
-   └── SearchService::search(SearchQuery) awaits
-   └── delegates to dyn SearchProvider
+3. src/app/search_service.rs or src/app/fanout_search_service.rs
+   └── SearchService::search(SearchQuery) awaits one provider
+   └── FanoutSearchService::search_all(SearchQuery) awaits enabled providers sequentially
+   └── delegates to dyn SearchProvider trait objects
 
 4. src/providers/*/client.rs
    └── provider-specific SearchProvider::search(&SearchQuery)
@@ -62,7 +63,8 @@ bootstrap composes app + providers + transport at startup
    └── transforms DTOs into domain SearchResult::News items
 
 7. src/cli/output.rs
-   └── render_text(&SearchResponse) → String
+   └── render_text(&SearchResponse) → String for single-provider output
+   └── render_fanout_text(&SearchBatchResponse) → String for all-provider output
 
 8. src/main.rs
    └── println!("{}", rendered_string)
@@ -75,11 +77,13 @@ Every public function that crosses a module boundary uses a domain type.
 | Boundary | Function | Input type | Output type |
 |----------|----------|------------|-------------|
 | CLI → App | `SearchService::search` | `SearchQuery` | `Result<SearchResponse, SearchError>` |
+| CLI → App | `FanoutSearchService::search_all` | `SearchQuery` | `SearchBatchResponse` |
 | App → Provider | `SearchProvider::search` | `&SearchQuery` | `Result<SearchResponse, SearchError>` |
 | Provider → Transport | `HttpClient::{get_json, post_json}` | `url, headers, params/body` | `Result<T, SearchError>` |
 | Transport → Provider | (JSON response body) | bytes | provider DTOs such as `Brave*Response` or `ExaSearchResponse` |
 | Provider → Domain | `map_*_response` | provider DTOs | `SearchResponse` |
-| App → CLI | `render_text` | `&SearchResponse` | `String` |
+| CLI rendering | `render_text` | `&SearchResponse` | `String` |
+| CLI rendering | `render_fanout_text` | `&SearchBatchResponse` | `String` |
 
 ## Domain type reference
 
@@ -105,7 +109,7 @@ pub struct SearchResponse {
     pub query: String,
     pub provider: String,
     pub results: Vec<SearchResult>,
-    pub total_estimated: Option<usize>,
+    pub total_estimated: Option<u64>,
     pub next_page: Option<PageToken>,
 }
 ```
@@ -116,6 +120,21 @@ pub enum SearchResult {
     News(NewsResult),
     Image(ImageResult),
     Video(VideoResult),
+}
+```
+
+Fan-out results stay provider-agnostic in the domain layer:
+
+```rust
+pub struct SearchBatchResponse {
+    pub query: String,
+    pub responses: Vec<SearchResponse>,
+    pub failures: Vec<ProviderSearchFailure>,
+}
+
+pub struct ProviderSearchFailure {
+    pub provider: String,
+    pub error: SearchError,
 }
 ```
 
@@ -148,8 +167,8 @@ Errors are created at the layer where the failure occurs and bubble upward uncha
 
 1. **Transport layer** — `reqwest` failures, non-2xx HTTP status, or JSON decode errors become `SearchError::Transport`, `SearchError::Provider`, or `SearchError::Decode`.
 2. **Provider layer** — can surface `SearchError` directly; does not wrap in another error type.
-3. **App layer** — `SearchService` returns the `SearchError` untouched.
-4. **CLI layer** — `main.rs` matches on `SearchError` and prints a human-readable message to `stderr`, then exits with code `1`.
+3. **App layer** — `SearchService` returns the `SearchError` untouched; `FanoutSearchService` records per-provider failures in `SearchBatchResponse` and continues to later providers.
+4. **CLI layer** — `main.rs` matches on single-provider `SearchError` and prints a human-readable message to `stderr`, or renders fan-out successes and failures and exits with code `1` when no provider succeeded.
 
 This keeps error handling simple: there is only one error type in the public API.
 
@@ -177,11 +196,14 @@ Unsupported Exa inputs are rejected at runtime instead of being ignored: `Images
 
 ## Runtime provider selection
 
-`main.rs` remains the binary edge that chooses the requested provider ID. Concrete provider construction lives in `src/bootstrap/provider_registry.rs`, where typed provider config, HTTP transport, provider clients, and `SearchService` are composed.
+`main.rs` remains the binary edge that chooses either a single-provider path or the all-enabled-provider fan-out path. Concrete provider construction lives in `src/bootstrap/provider_registry.rs`, where typed provider config, HTTP transport, provider clients, `SearchService`, and `FanoutSearchService` are composed.
 
-- `--provider brave` maps to `ProviderId::Brave`; the registry includes it only when `BRAVE_API_KEY` is configured
-- `--provider exa` maps to `ProviderId::Exa`; the registry includes it only when `EXA_API_KEY` is configured
+- `--provider brave` uses `ProviderRegistry::build(ProviderId::Brave)`; the registry includes it only when `BRAVE_API_KEY` is configured
+- `--provider exa` uses `ProviderRegistry::build(ProviderId::Exa)`; the registry includes it only when `EXA_API_KEY` is configured
+- `--provider all` uses `ProviderRegistry::build_all_enabled()` to build a `FanoutSearchService` from every configured provider in stable order
 - omitting `--provider` still selects Brave
+
+`FanoutSearchService` is application-layer orchestration over multiple domain `SearchProvider` trait objects. It does not render output; fan-out rendering remains in the CLI layer through `render_fanout_text`.
 
 ## Architecture enforcement
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -12,21 +12,22 @@ ontology_relations:
 
 # sophon-cli
 
-A provider-agnostic Rust CLI that queries the Brave Search API and prints normalized text results.
+A provider-agnostic Rust CLI that queries Brave Search, Exa, or every environment-enabled provider and prints normalized text results.
 
 ## What it does
 
 - Parses CLI arguments
 - Builds a provider-agnostic `SearchQuery`
-- Delegates to a `SearchProvider` (currently Brave)
-- Renders results as human-readable text
+- Delegates to a single `SearchProvider` for `--provider brave` or `--provider exa`
+- Fans out sequentially to all environment-enabled providers for `--provider all`
+- Renders single-provider or per-provider fan-out results as human-readable text
 
 ## Project structure
 
 - `src/domain/` — pure types and traits; no HTTP, no CLI
 - `src/transport/` — `HttpClient` trait + `reqwest` adapter
 - `src/providers/brave/` — Brave-specific DTOs, mapper, and client
-- `src/app/` — `SearchService` orchestrator
+- `src/app/` — `SearchService` and `FanoutSearchService` orchestrators
 - `src/cli/` — argument parsing and output rendering
 - `tests/architecture_test.rs` — boundary tests enforcing layer isolation
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,7 @@ ontology_relations:
 ## Prerequisites
 
 - Rust toolchain (edition 2024)
-- `BRAVE_API_KEY` in a `.env` file at the project root
+- `BRAVE_API_KEY` and/or `EXA_API_KEY` in a `.env` file at the project root
 
 ## Install the task runner
 
@@ -34,6 +34,18 @@ just check
 ```bash
 cargo run -- "rust programming"
 ```
+
+## Run all configured providers
+
+Set both provider keys when you want `--provider all` to query Brave and Exa in one run:
+
+```bash
+export BRAVE_API_KEY=your_brave_key
+export EXA_API_KEY=your_exa_key
+cargo run -- "rust async trait" --provider all
+```
+
+`--provider all` includes only providers enabled by the current environment variables. If neither `BRAVE_API_KEY` nor `EXA_API_KEY` is available, the command exits non-zero and prints `no configured providers; set BRAVE_API_KEY and/or EXA_API_KEY`.
 
 ## Search news
 

--- a/src/app/fanout_search_service.rs
+++ b/src/app/fanout_search_service.rs
@@ -1,0 +1,135 @@
+use crate::domain::provider::SearchProvider;
+use crate::domain::query::SearchQuery;
+use crate::domain::result::{ProviderSearchFailure, SearchBatchResponse, SearchResponse};
+
+pub struct FanoutSearchService {
+    providers: Vec<Box<dyn SearchProvider>>,
+}
+
+impl FanoutSearchService {
+    pub fn new(providers: Vec<Box<dyn SearchProvider>>) -> Self {
+        Self { providers }
+    }
+
+    pub async fn search_all(&self, query: SearchQuery) -> SearchBatchResponse {
+        let mut responses: Vec<SearchResponse> = Vec::new();
+        let mut failures: Vec<ProviderSearchFailure> = Vec::new();
+
+        for provider in &self.providers {
+            let provider_id = provider.id();
+            match provider.search(&query).await {
+                Ok(response) => responses.push(response),
+                Err(error) => failures.push(ProviderSearchFailure {
+                    provider: provider_id,
+                    error,
+                }),
+            }
+        }
+
+        SearchBatchResponse {
+            query: query.text,
+            responses,
+            failures,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::error::SearchError;
+    use crate::domain::provider::{ProviderCapabilities, SearchProvider};
+    use crate::domain::query::SearchQuery;
+    use crate::domain::result::SearchResponse;
+    use crate::domain::types::SearchType;
+    use async_trait::async_trait;
+
+    enum MockOutcome {
+        Success(SearchResponse),
+        Failure(&'static str),
+    }
+
+    struct MockProvider {
+        id: &'static str,
+        outcome: MockOutcome,
+    }
+
+    #[async_trait]
+    impl SearchProvider for MockProvider {
+        fn id(&self) -> String {
+            self.id.to_string()
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                web: true,
+                news: false,
+                images: false,
+                videos: false,
+                pagination: false,
+                safe_search: false,
+                time_range_filter: false,
+            }
+        }
+
+        async fn search(&self, _query: &SearchQuery) -> Result<SearchResponse, SearchError> {
+            match &self.outcome {
+                MockOutcome::Success(response) => Ok(response.clone()),
+                MockOutcome::Failure(message) => Err(SearchError::Provider(message.to_string())),
+            }
+        }
+    }
+
+    fn response(provider: &str) -> SearchResponse {
+        SearchResponse {
+            query: "rust".to_string(),
+            provider: provider.to_string(),
+            results: vec![],
+            total_estimated: None,
+            next_page: None,
+        }
+    }
+
+    fn query() -> SearchQuery {
+        SearchQuery {
+            text: "rust".to_string(),
+            search_type: SearchType::Web,
+            limit: None,
+            offset: None,
+            safe_search: None,
+            country: None,
+            language: None,
+            time_range: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn search_all_preserves_provider_order_and_records_failures() {
+        let service = FanoutSearchService::new(vec![
+            Box::new(MockProvider {
+                id: "brave",
+                outcome: MockOutcome::Success(response("brave")),
+            }),
+            Box::new(MockProvider {
+                id: "broken",
+                outcome: MockOutcome::Failure("temporary outage"),
+            }),
+            Box::new(MockProvider {
+                id: "exa",
+                outcome: MockOutcome::Success(response("exa")),
+            }),
+        ]);
+
+        let batch = service.search_all(query()).await;
+
+        assert_eq!(batch.query, "rust");
+        assert_eq!(batch.responses[0].provider, "brave");
+        assert_eq!(batch.responses[1].provider, "exa");
+        assert_eq!(batch.failures.len(), 1);
+        assert_eq!(batch.failures[0].provider, "broken");
+        assert_eq!(
+            batch.failures[0].error.to_string(),
+            "provider error: temporary outage"
+        );
+    }
+}

--- a/src/app/fanout_search_service.rs
+++ b/src/app/fanout_search_service.rs
@@ -63,12 +63,7 @@ mod tests {
         fn capabilities(&self) -> ProviderCapabilities {
             ProviderCapabilities {
                 web: true,
-                news: false,
-                images: false,
-                videos: false,
-                pagination: false,
-                safe_search: false,
-                time_range_filter: false,
+                ..ProviderCapabilities::default()
             }
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,1 +1,2 @@
+pub mod fanout_search_service;
 pub mod search_service;

--- a/src/app/search_service.rs
+++ b/src/app/search_service.rs
@@ -43,12 +43,7 @@ mod tests {
         fn capabilities(&self) -> ProviderCapabilities {
             ProviderCapabilities {
                 web: true,
-                news: false,
-                images: false,
-                videos: false,
-                pagination: false,
-                safe_search: false,
-                time_range_filter: false,
+                ..ProviderCapabilities::default()
             }
         }
 

--- a/src/bootstrap/provider_registry.rs
+++ b/src/bootstrap/provider_registry.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
+use crate::app::fanout_search_service::FanoutSearchService;
 use crate::app::search_service::SearchService;
 use crate::domain::provider::SearchProvider;
 use crate::providers::brave::client::BraveProvider;
@@ -37,6 +38,8 @@ pub enum BuildSearchServiceError {
         provider: ProviderId,
         available: Vec<ProviderId>,
     },
+    #[error("no configured providers; set BRAVE_API_KEY and/or EXA_API_KEY")]
+    NoProvidersAvailable,
 }
 
 impl ProviderRegistry {
@@ -97,6 +100,26 @@ impl ProviderRegistry {
 
         Ok(SearchService::new(builder()))
     }
+
+    pub fn build_all_enabled(&self) -> Result<FanoutSearchService, BuildSearchServiceError> {
+        let provider_ids = self.available_providers();
+        if provider_ids.is_empty() {
+            return Err(BuildSearchServiceError::NoProvidersAvailable);
+        }
+
+        let providers = provider_ids
+            .into_iter()
+            .map(|provider_id| {
+                let builder = self
+                    .builders
+                    .get(&provider_id)
+                    .expect("available provider has a registered builder");
+                builder()
+            })
+            .collect();
+
+        Ok(FanoutSearchService::new(providers))
+    }
 }
 
 #[cfg(test)]
@@ -106,6 +129,7 @@ mod tests {
     use crate::domain::provider::ProviderCapabilities;
     use crate::domain::query::SearchQuery;
     use crate::domain::result::SearchResponse;
+    use crate::domain::types::SearchType;
     use async_trait::async_trait;
     use std::ffi::OsString;
     use std::sync::{Mutex, OnceLock};
@@ -141,6 +165,52 @@ mod tests {
         }
     }
 
+    struct NamedMockProvider {
+        id: &'static str,
+    }
+
+    #[async_trait]
+    impl SearchProvider for NamedMockProvider {
+        fn id(&self) -> String {
+            self.id.to_string()
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                web: true,
+                news: true,
+                images: false,
+                videos: false,
+                pagination: false,
+                safe_search: false,
+                time_range_filter: false,
+            }
+        }
+
+        async fn search(&self, query: &SearchQuery) -> Result<SearchResponse, SearchError> {
+            Ok(SearchResponse {
+                query: query.text.clone(),
+                provider: self.id.to_string(),
+                results: vec![],
+                total_estimated: None,
+                next_page: None,
+            })
+        }
+    }
+
+    fn search_query() -> SearchQuery {
+        SearchQuery {
+            text: "rust".to_string(),
+            search_type: SearchType::Web,
+            limit: None,
+            offset: None,
+            safe_search: None,
+            country: None,
+            language: None,
+            time_range: None,
+        }
+    }
+
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
@@ -170,6 +240,7 @@ mod tests {
                 assert!(available.is_empty());
             }
             Ok(_) => panic!("expected ProviderUnavailable error"),
+            Err(other) => panic!("expected ProviderUnavailable error, got {other}"),
         }
     }
 
@@ -211,5 +282,38 @@ mod tests {
             registry.available_providers(),
             vec![ProviderId::Brave, ProviderId::Exa]
         );
+    }
+
+    #[tokio::test]
+    async fn build_all_enabled_uses_stable_order_and_rejects_empty_registry() {
+        let empty = ProviderRegistry::empty();
+        match empty.build_all_enabled() {
+            Err(BuildSearchServiceError::NoProvidersAvailable) => {}
+            Ok(_) => panic!("expected NoProvidersAvailable error"),
+            Err(other) => panic!("expected NoProvidersAvailable error, got {other}"),
+        }
+
+        let mut registry = ProviderRegistry::empty();
+        registry.register(
+            ProviderId::Exa,
+            Box::new(|| Box::new(NamedMockProvider { id: "exa" })),
+        );
+        registry.register(
+            ProviderId::Brave,
+            Box::new(|| Box::new(NamedMockProvider { id: "brave" })),
+        );
+
+        let service = registry
+            .build_all_enabled()
+            .expect("fan-out service builds");
+        let batch = service.search_all(search_query()).await;
+
+        let providers: Vec<&str> = batch
+            .responses
+            .iter()
+            .map(|response| response.provider.as_str())
+            .collect();
+        assert_eq!(providers, vec!["brave", "exa"]);
+        assert!(batch.failures.is_empty());
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -41,6 +41,7 @@ impl From<CliSafeSearch> for crate::domain::types::SafeSearch {
 pub enum CliProvider {
     Brave,
     Exa,
+    All,
 }
 
 #[derive(Parser, Debug)]
@@ -87,6 +88,17 @@ mod tests {
         assert_eq!(exa_args.search_type, CliSearchType::Web);
 
         let default_args = CliArgs::parse_from(["sophon-cli", "rust"]);
+        assert_eq!(default_args.provider, CliProvider::Brave);
+    }
+
+    #[test]
+    fn test_cli_provider_parses_all_and_defaults_to_brave() {
+        let all_args = CliArgs::try_parse_from(["sophon-cli", "rust", "--provider", "all"])
+            .expect("all provider parses");
+        assert_eq!(all_args.provider, CliProvider::All);
+
+        let default_args =
+            CliArgs::try_parse_from(["sophon-cli", "rust"]).expect("default provider parses");
         assert_eq!(default_args.provider, CliProvider::Brave);
     }
 }

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -1,4 +1,4 @@
-use crate::domain::result::{SearchResponse, SearchResult};
+use crate::domain::result::{SearchBatchResponse, SearchResponse, SearchResult};
 
 pub fn render_text(response: &SearchResponse) -> String {
     let mut lines = vec![
@@ -46,9 +46,34 @@ pub fn render_text(response: &SearchResponse) -> String {
     lines.join("\n")
 }
 
+pub fn render_fanout_text(response: &SearchBatchResponse) -> String {
+    let mut lines = vec![
+        format!("Query: {}", response.query),
+        format!("Providers succeeded: {}", response.responses.len()),
+        format!("Providers failed: {}", response.failures.len()),
+        String::new(),
+    ];
+
+    for provider_response in &response.responses {
+        lines.push(format!("== {} ==", provider_response.provider));
+        lines.push(render_text(provider_response));
+        lines.push(String::new());
+    }
+
+    if !response.failures.is_empty() {
+        lines.push("== Failures ==".to_string());
+        for failure in &response.failures {
+            lines.push(format!("- {}: {}", failure.provider, failure.error));
+        }
+    }
+
+    lines.join("\n")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::error::SearchError;
     use crate::domain::result::*;
 
     #[test]
@@ -96,5 +121,37 @@ mod tests {
         assert!(text.contains("Breaking update"));
         assert!(text.contains("[IMAGE] Rust Logo"));
         assert!(text.contains("[VIDEO] Rust Tutorial"));
+    }
+
+    #[test]
+    fn test_render_fanout_text_includes_successes_and_failures() {
+        let response = SearchBatchResponse {
+            query: "rust".to_string(),
+            responses: vec![SearchResponse {
+                query: "rust".to_string(),
+                provider: "brave".to_string(),
+                results: vec![SearchResult::Web(WebResult {
+                    title: "Rust Lang".to_string(),
+                    url: "https://rust-lang.org".to_string(),
+                    snippet: Some("Safe systems".to_string()),
+                    display_url: None,
+                })],
+                total_estimated: None,
+                next_page: None,
+            }],
+            failures: vec![ProviderSearchFailure {
+                provider: "exa".to_string(),
+                error: SearchError::InvalidQuery("unsupported".to_string()),
+            }],
+        };
+
+        let text = render_fanout_text(&response);
+
+        assert!(text.contains("Query: rust"));
+        assert!(text.contains("Providers succeeded: 1"));
+        assert!(text.contains("Providers failed: 1"));
+        assert!(text.contains("== brave =="));
+        assert!(text.contains("Rust Lang"));
+        assert!(text.contains("- exa: invalid query: unsupported"));
     }
 }

--- a/src/domain/provider.rs
+++ b/src/domain/provider.rs
@@ -3,7 +3,7 @@ use crate::domain::query::SearchQuery;
 use crate::domain::result::SearchResponse;
 use async_trait::async_trait;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 #[allow(dead_code)]
 pub struct ProviderCapabilities {
     pub web: bool,

--- a/src/domain/result.rs
+++ b/src/domain/result.rs
@@ -1,3 +1,5 @@
+use crate::domain::error::SearchError;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PageToken(pub String);
 
@@ -8,6 +10,19 @@ pub struct SearchResponse {
     pub results: Vec<SearchResult>,
     pub total_estimated: Option<u64>,
     pub next_page: Option<PageToken>,
+}
+
+#[derive(Debug)]
+pub struct SearchBatchResponse {
+    pub query: String,
+    pub responses: Vec<SearchResponse>,
+    pub failures: Vec<ProviderSearchFailure>,
+}
+
+#[derive(Debug)]
+pub struct ProviderSearchFailure {
+    pub provider: String,
+    pub error: SearchError,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -50,4 +65,38 @@ pub struct VideoResult {
     pub thumbnail_url: Option<String>,
     pub duration: Option<String>,
     pub published_at: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::error::SearchError;
+
+    #[test]
+    fn search_batch_response_can_hold_success_and_failure() {
+        let response = SearchResponse {
+            query: "rust".to_string(),
+            provider: "brave".to_string(),
+            results: vec![],
+            total_estimated: None,
+            next_page: None,
+        };
+        let failure = ProviderSearchFailure {
+            provider: "exa".to_string(),
+            error: SearchError::InvalidQuery("unsupported".to_string()),
+        };
+        let batch = SearchBatchResponse {
+            query: "rust".to_string(),
+            responses: vec![response],
+            failures: vec![failure],
+        };
+
+        assert_eq!(batch.query, "rust");
+        assert_eq!(batch.responses[0].provider, "brave");
+        assert_eq!(batch.failures[0].provider, "exa");
+        assert_eq!(
+            batch.failures[0].error.to_string(),
+            "invalid query: unsupported"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ impl From<CliProvider> for ProviderId {
         match provider {
             CliProvider::Brave => ProviderId::Brave,
             CliProvider::Exa => ProviderId::Exa,
+            CliProvider::All => panic!("all-provider mode is handled by fan-out wiring"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,16 +8,32 @@ mod transport;
 use bootstrap::provider_registry::{ProviderId, ProviderRegistry};
 use clap::Parser;
 use cli::args::{CliArgs, CliProvider};
-use cli::output::render_text;
+use cli::output::{render_fanout_text, render_text};
 use domain::query::SearchQuery;
 use tracing_subscriber::EnvFilter;
 
-impl From<CliProvider> for ProviderId {
-    fn from(provider: CliProvider) -> Self {
-        match provider {
-            CliProvider::Brave => ProviderId::Brave,
-            CliProvider::Exa => ProviderId::Exa,
-            CliProvider::All => panic!("all-provider mode is handled by fan-out wiring"),
+async fn run_single_provider(
+    registry: &ProviderRegistry,
+    provider_id: ProviderId,
+    query: SearchQuery,
+) {
+    tracing::info!(provider = %provider_id, query = %query.text, "initializing search service");
+
+    let service = registry.build(provider_id).unwrap_or_else(|error| {
+        tracing::error!(%error, "failed to build provider");
+        eprintln!("{error}");
+        std::process::exit(1);
+    });
+
+    match service.search(query).await {
+        Ok(response) => {
+            tracing::info!(result_count = response.results.len(), total_estimated = ?response.total_estimated, "search completed");
+            println!("{}", render_text(&response));
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "search failed");
+            eprintln!("Search failed: {}", e);
+            std::process::exit(1);
         }
     }
 }
@@ -64,25 +80,29 @@ async fn main() {
         time_range: None,
     };
 
-    let provider_id = ProviderId::from(args.provider);
-    tracing::info!(provider = %provider_id, query = %query.text, "initializing search service");
-
     let registry = ProviderRegistry::production_from_env();
-    let service = registry.build(provider_id).unwrap_or_else(|error| {
-        tracing::error!(%error, "failed to build provider");
-        eprintln!("{error}");
-        std::process::exit(1);
-    });
 
-    match service.search(query).await {
-        Ok(response) => {
-            tracing::info!(result_count = response.results.len(), total_estimated = ?response.total_estimated, "search completed");
-            println!("{}", render_text(&response));
-        }
-        Err(e) => {
-            tracing::error!(error = %e, "search failed");
-            eprintln!("Search failed: {}", e);
-            std::process::exit(1);
+    match args.provider {
+        CliProvider::Brave => run_single_provider(&registry, ProviderId::Brave, query).await,
+        CliProvider::Exa => run_single_provider(&registry, ProviderId::Exa, query).await,
+        CliProvider::All => {
+            tracing::info!(query = %query.text, "initializing all-enabled provider fan-out service");
+            let service = registry.build_all_enabled().unwrap_or_else(|error| {
+                tracing::error!(%error, "failed to build fan-out providers");
+                eprintln!("{error}");
+                std::process::exit(1);
+            });
+
+            let response = service.search_all(query).await;
+            tracing::info!(
+                successful_providers = response.responses.len(),
+                failed_providers = response.failures.len(),
+                "fan-out search completed"
+            );
+            println!("{}", render_fanout_text(&response));
+            if response.responses.is_empty() {
+                std::process::exit(1);
+            }
         }
     }
 }

--- a/src/providers/exa/mapper.rs
+++ b/src/providers/exa/mapper.rs
@@ -7,28 +7,32 @@ const SNIPPET_DISPLAY_MAX_CHARS: usize = 500;
 const HIGHLIGHT_JOIN: &str = " … ";
 
 pub fn map_web_response(query: &str, dto: ExaSearchResponse) -> SearchResponse {
-    SearchResponse {
-        query: query.to_string(),
-        provider: "exa".to_string(),
-        total_estimated: None,
-        next_page: None,
-        results: dto
-            .results
-            .into_iter()
-            .map(|result| {
-                let snippet = preferred_snippet(&result);
-                SearchResult::Web(WebResult {
-                    title: result.title.unwrap_or_default(),
-                    url: result.url.unwrap_or_default(),
-                    snippet,
-                    display_url: None,
-                })
-            })
-            .collect(),
-    }
+    map_response(query, dto, |result, snippet| {
+        SearchResult::Web(WebResult {
+            title: result.title.unwrap_or_default(),
+            url: result.url.unwrap_or_default(),
+            snippet,
+            display_url: None,
+        })
+    })
 }
 
 pub fn map_news_response(query: &str, dto: ExaSearchResponse) -> SearchResponse {
+    map_response(query, dto, |result, snippet| {
+        SearchResult::News(NewsResult {
+            title: result.title.unwrap_or_default(),
+            url: result.url.unwrap_or_default(),
+            snippet,
+            source: result.author,
+            published_at: result.published_date,
+        })
+    })
+}
+
+fn map_response<F>(query: &str, dto: ExaSearchResponse, map_result: F) -> SearchResponse
+where
+    F: Fn(ExaResult, Option<String>) -> SearchResult,
+{
     SearchResponse {
         query: query.to_string(),
         provider: "exa".to_string(),
@@ -39,13 +43,7 @@ pub fn map_news_response(query: &str, dto: ExaSearchResponse) -> SearchResponse 
             .into_iter()
             .map(|result| {
                 let snippet = preferred_snippet(&result);
-                SearchResult::News(NewsResult {
-                    title: result.title.unwrap_or_default(),
-                    url: result.url.unwrap_or_default(),
-                    snippet,
-                    source: result.author,
-                    published_at: result.published_date,
-                })
+                map_result(result, snippet)
             })
             .collect(),
     }

--- a/tests/fanout_cli_test.rs
+++ b/tests/fanout_cli_test.rs
@@ -1,0 +1,19 @@
+use std::process::Command;
+
+#[test]
+fn provider_all_without_config_exits_nonzero_with_no_provider_error() {
+    let output = Command::new(env!("CARGO_BIN_EXE_sophon-cli"))
+        .args(["rust", "--provider", "all"])
+        .env_remove("BRAVE_API_KEY")
+        .env_remove("EXA_API_KEY")
+        .current_dir(std::env::temp_dir())
+        .output()
+        .expect("sophon-cli runs");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no configured providers"),
+        "stderr did not contain no configured providers: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- add domain batch response and app-layer fan-out service for querying all enabled providers
- extend provider registry, CLI provider parsing, and main wiring for `--provider all`
- render per-provider successes/failures and document all-provider mode

## Validation
- `just check`

## Notes
- PR branch intentionally excludes the local rollback marker commit used during execute-phase; it contains the seven task commits only.