### PR TITLE
[codex] Add provider catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration test suite for app-layer fan-out, provider registry, and CLI argument parsing. (#12)
 - Changelog coverage test that verifies merged PRs are referenced in `CHANGELOG.md`. (#17)
 - Markdown artifact control-plane docs, a compact `AGENTS.md` map, and `.DS_Store` cleanup. (#18)
+- Bootstrap provider catalog as the single source of truth for provider identity, CLI tokens, environment variable metadata, stable ordering, and production provider construction. (#19)
 
 ### Changed
 

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -140,7 +140,8 @@ Ordered list of hygiene checks as executed by the hygiene entry point:
 | `docs/` | mdBook source: intro, architecture, quickstart |
 | `book.toml` | mdBook configuration |
 | `Cargo.toml` | Project manifest, dependencies, edition 2024, cargo-husky hook installer |
-| `src/bootstrap/provider_registry.rs` | Built-in provider registry and service construction tests |
+| `src/bootstrap/provider_catalog.rs` | Built-in provider identity, CLI tokens, env vars, stable order, and production builders |
+| `src/bootstrap/provider_registry.rs` | Registry construction from the provider catalog and service composition tests |
 | `src/providers/brave/mapper.rs` | 4 unit tests for DTO→domain mapping |
 | `src/providers/brave/client.rs` | 1 mock-HTTP unit test for Brave provider |
 | `src/app/search_service.rs` | 1 mock-provider unit test for SearchService |

--- a/README.md
+++ b/README.md
@@ -64,9 +64,14 @@ sophon-cli "rust async trait" --provider all
 
 ## Supported providers
 
+Real provider tokens:
+
 - `brave` for web, news, images, and video search
 - `exa` for Exa search results mapped into the shared domain model
-- `all` to query every configured provider in stable order and print per-provider failures when one provider rejects or fails a request
+
+`all` is a CLI-only selection mode. It queries every configured real provider in catalog order and prints per-provider failures when one provider rejects or fails a request.
+
+Maintainers add or change provider identity, display names, environment variable names, stable ordering, and production wiring in `src/bootstrap/provider_catalog.rs`.
 
 ## Docs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -201,12 +201,14 @@ Unsupported Exa inputs are rejected at runtime instead of being ignored: `Images
 
 ## Runtime provider selection
 
-`src/main.rs` remains a thin process entrypoint. It initializes process-level concerns and delegates to `src/cli/runner.rs`, which owns user-surface branching, query normalization, output rendering, and exit-code calculation. Concrete provider construction remains in `src/bootstrap/provider_registry.rs`, where typed provider config, HTTP transport, provider clients, `SearchService`, and `FanoutSearchService` are composed.
+`src/main.rs` remains a thin process entrypoint. It initializes process-level concerns and delegates to `src/cli/runner.rs`, which owns user-surface branching, query normalization, output rendering, and exit-code calculation.
 
-- `--provider brave` uses `ProviderRegistry::build(ProviderId::Brave)`; the registry includes it only when `BRAVE_API_KEY` is configured
-- `--provider exa` uses `ProviderRegistry::build(ProviderId::Exa)`; the registry includes it only when `EXA_API_KEY` is configured
-- `--provider all` uses `ProviderRegistry::build_all_enabled()` to build a `FanoutSearchService` from every configured provider in stable order
-- omitting `--provider` still selects Brave
+Real provider identity and production construction live in `src/bootstrap/provider_catalog.rs`. The catalog declares each real provider's `ProviderId`, CLI token, display name, environment variable name, stable order, and production builder. `src/bootstrap/provider_registry.rs` consumes that catalog to register configured providers and compose `SearchService` or `FanoutSearchService`.
+
+- `--provider brave` resolves the catalog token to `ProviderId::Brave`; the registry includes it only when `BRAVE_API_KEY` is configured
+- `--provider exa` resolves the catalog token to `ProviderId::Exa`; the registry includes it only when `EXA_API_KEY` is configured
+- `--provider all` is a CLI-only aggregate mode that uses `ProviderRegistry::build_all_enabled()` to build a `FanoutSearchService` from every configured real provider in catalog order
+- omitting `--provider` still selects the first catalog provider, currently Brave
 
 `FanoutSearchService` is application-layer orchestration over multiple domain `SearchProvider` trait objects. It does not render output; fan-out rendering remains in the CLI layer through `render_fanout_text`.
 

--- a/docs/artifacts/active/CHARTER-20260530-provider-catalog.md
+++ b/docs/artifacts/active/CHARTER-20260530-provider-catalog.md
@@ -25,7 +25,7 @@ ontology_relations:
 | Date | 2026-05-30 |
 | Owner | Codex |
 | Related Artifacts | `docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md`, `docs/artifacts/memory/MEM-20260530-provider-catalog-research.md`, `docs/artifacts/decisions/ADR-0001-provider-catalog.md`, `docs/artifacts/evidence/EVID-20260530-provider-catalog.md`, `docs/artifacts/memory/MEM-20260530-provider-catalog-implementation.md` |
-| Related Files | `src/bootstrap/provider_registry.rs`, `src/bootstrap/mod.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`, `README.md`, `docs/intro.md`, `docs/quickstart.md`, `docs/project/ARCHITECTURE.md`, `docs/architecture.md`, `HARNESS.md` |
+| Related Files | `src/bootstrap/provider_registry.rs`, `src/bootstrap/mod.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`, `README.md`, `CHANGELOG.md`, `docs/intro.md`, `docs/quickstart.md`, `docs/project/ARCHITECTURE.md`, `docs/architecture.md`, `HARNESS.md` |
 
 ## Mission
 
@@ -63,6 +63,7 @@ Feature
 - Add source-scan guardrails that forbid duplicated provider identities in CLI and bootstrap wiring outside the catalog and provider config modules.
 - Update provider registry and CLI integration tests to assert catalog-backed behavior.
 - Clean up user and maintainer docs so provider registration points to the catalog as the single source of truth.
+- Add this PR's assigned number to `CHANGELOG.md` before merge so changelog coverage remains satisfied after landing.
 - Update architecture and harness docs if their current provider registry contract becomes stale.
 
 ### Out of Scope

--- a/docs/artifacts/active/CHARTER-20260530-provider-catalog.md
+++ b/docs/artifacts/active/CHARTER-20260530-provider-catalog.md
@@ -1,0 +1,147 @@
+---
+title: "Session charter: provider catalog"
+when_to_read:
+  - "When implementing the provider catalog refactor for sophon-cli."
+  - "Before changing provider selection, provider registry construction, or provider documentation."
+summary: "Defines the feature scope, constraints, regression checks, and execution plan for making a provider catalog the authoritative source for provider identity and production wiring."
+ontology_relations:
+  - relation: "governs"
+    target: "sophon-cli-provider-catalog"
+    note: "Sets the execution scope for the provider catalog refactor."
+  - relation: "depends_on"
+    target: "docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md"
+    note: "Uses the focused exploration that mapped duplicated provider metadata."
+  - relation: "implements"
+    target: "docs/artifacts/decisions/ADR-0001-provider-catalog.md"
+    note: "Executes the durable decision that provider identity and production wiring belong to a catalog."
+---
+
+# Session Charter
+
+| Field | Value |
+|---|---|
+| Artifact Type | Session Charter |
+| Status | Completed |
+| Date | 2026-05-30 |
+| Owner | Codex |
+| Related Artifacts | `docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md`, `docs/artifacts/memory/MEM-20260530-provider-catalog-research.md`, `docs/artifacts/decisions/ADR-0001-provider-catalog.md`, `docs/artifacts/evidence/EVID-20260530-provider-catalog.md`, `docs/artifacts/memory/MEM-20260530-provider-catalog-implementation.md` |
+| Related Files | `src/bootstrap/provider_registry.rs`, `src/bootstrap/mod.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`, `README.md`, `docs/intro.md`, `docs/quickstart.md`, `docs/project/ARCHITECTURE.md`, `docs/architecture.md`, `HARNESS.md` |
+
+## Mission
+
+Create a bootstrap-owned provider catalog so provider identity, CLI token lookup, display names, environment variable names, stable provider ordering, and production provider construction have one authoritative source.
+
+## Work Type
+
+Feature
+
+## Context
+
+- `docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md` found live provider metadata duplication across CLI parsing, CLI runner selection, bootstrap registry IDs, provider env config, stable ordering, tests, and docs.
+- Current source repeats `Brave` and `Exa` knowledge in `CliProvider`, `ProviderId`, `ProviderRegistry::production_from_env`, `ProviderRegistry::available_providers`, about text, tests, and docs.
+- Grill decisions resolved that the catalog should be a static ordered slice, should contain only real providers, and should not include the `all` aggregate mode.
+- Unknown provider tokens should fail gracefully at argument parse time with valid catalog tokens plus `all`.
+- A durable decision record is required because provider identity ownership is changing.
+
+## Scope
+
+### In Scope
+
+- Add a provider catalog module under `src/bootstrap/`.
+- Move or re-home `ProviderId` so provider identity is defined through the catalog surface.
+- Make the catalog authoritative for:
+  - provider id
+  - CLI token
+  - display name
+  - environment variable name
+  - stable provider order
+  - production builder
+- Keep `all` as a CLI-only aggregate selection mode that builds every environment-enabled real provider in catalog order.
+- Replace hardcoded CLI provider value parsing with catalog-backed provider token lookup.
+- Preserve graceful parse-time errors for unknown provider tokens.
+- Add a failing-first regression or architecture test that requires CLI and bootstrap provider wiring to use the catalog.
+- Add source-scan guardrails that forbid duplicated provider identities in CLI and bootstrap wiring outside the catalog and provider config modules.
+- Update provider registry and CLI integration tests to assert catalog-backed behavior.
+- Clean up user and maintainer docs so provider registration points to the catalog as the single source of truth.
+- Update architecture and harness docs if their current provider registry contract becomes stale.
+
+### Out of Scope
+
+- Adding a third provider.
+- Changing provider API DTO mapping, request construction, or result rendering.
+- Moving provider-specific request fields into `src/domain/`.
+- Changing domain provider contracts or `ProviderCapabilities`.
+- Changing fan-out concurrency, output format, stdout/stderr behavior, or exit-code semantics.
+- Running live Brave or Exa API calls as required evidence.
+- Refactoring unrelated test fixtures or docs.
+
+## Constraints
+
+- No source edits before the failing catalog regression test is added.
+- `src/domain/` must remain provider-agnostic and must not import bootstrap, providers, transport, CLI, or app layers.
+- `src/app/` must continue to orchestrate through domain contracts only.
+- `src/bootstrap/` may import concrete providers, provider configs, app services, domain traits, and transport adapters, but must not import CLI.
+- `src/cli/` may use the bootstrap catalog for provider token parsing and selection, but must not construct concrete provider adapters.
+- Provider-specific config loading stays under `src/providers/<provider>/config.rs`.
+- Provider-specific DTOs and mappers stay under `src/providers/<provider>/`.
+- New tracked Markdown must pass `python3 scripts/check_markdown_frontmatter.py`.
+- Preserve existing CLI behavior unless this charter explicitly says otherwise.
+
+## Risk Areas
+
+- Replacing `clap::ValueEnum` with catalog-backed parsing could weaken help text or error quality.
+- Moving `ProviderId` could cause noisy test churn if compatibility exports are not planned carefully.
+- Source-scan tests can become brittle if they forbid legitimate provider strings in provider adapters, docs, or domain test fixtures.
+- The catalog could become too broad if provider capabilities, API mapping, or provider-specific request rules are pulled into it.
+- Docs may continue to list providers manually even after source wiring becomes catalog-backed.
+
+## Regression Checks
+
+- Existing CLI defaults still select Brave when no `--provider` is passed.
+- `--provider brave` and `--provider exa` still select explicit single-provider mode.
+- `--provider all` still queries every environment-enabled provider in stable catalog order.
+- Explicit unavailable-provider errors still mention the requested provider and configured providers.
+- Empty or missing API keys still make a provider unavailable.
+- Unknown provider tokens fail at argument parse time and mention valid provider tokens plus `all`.
+- Provider registry order remains Brave, then Exa.
+- Architecture boundary tests still enforce domain, transport, provider, app, bootstrap, and CLI layering.
+
+## Rollback Plan
+
+Revert the catalog module, restore the previous `CliProvider` and `ProviderId` definitions, restore direct `ProviderRegistry::production_from_env` construction, and remove the new catalog-specific regression tests and docs updates.
+
+## Plan
+
+1. Add the failing-first catalog regression tests.
+2. Add `src/bootstrap/provider_catalog.rs` with an ordered static catalog of real providers.
+3. Expose the catalog module from `src/bootstrap/mod.rs`.
+4. Move provider identity and display/token metadata to the catalog surface.
+5. Refactor `ProviderRegistry::production_from_env` and provider ordering to iterate catalog entries.
+6. Refactor CLI provider parsing to resolve real provider tokens from the catalog and keep `all` as CLI-only aggregate mode.
+7. Refactor CLI runner single-provider selection to use catalog-backed provider IDs instead of hardcoded provider matches.
+8. Update integration tests for provider registry behavior, CLI parsing, unknown-provider errors, and all-provider ordering.
+9. Update docs that describe supported providers, provider registration, env configuration, and runtime provider selection.
+10. Run targeted tests, then `just check`, then create evidence and session memory.
+
+## Evidence Required
+
+- A pre-implementation failing result for the catalog regression test, or a documented reason it could not be captured.
+- Passing targeted Rust tests for architecture, provider registry, and CLI parsing.
+- `python3 scripts/check_markdown_frontmatter.py` passes after docs updates.
+- `mdbook build` passes after docs updates.
+- `just check` passes, or any failure is documented in the evidence pack with the exact failing command and output summary.
+- Diff review confirms hardcoded provider identities were removed from CLI/bootstrap wiring outside allowed catalog and provider config locations.
+
+## Exit Criteria
+
+- Provider identity, CLI token lookup, display names, env var names, stable ordering, and production construction are sourced from the provider catalog.
+- `all` remains a CLI-only aggregate mode and is not represented as a catalog provider.
+- CLI and bootstrap no longer maintain separate provider lists for Brave and Exa.
+- Regression tests protect the catalog as the provider wiring source of truth.
+- User-facing and maintainer docs point future provider additions to the catalog.
+- ADR-0001 exists and records the durable decision.
+- Evidence and session memory artifacts exist for the implementation session.
+
+## Clarifications Needed Before Editing
+
+None.

--- a/docs/artifacts/active/EXEC-20260530-provider-catalog.md
+++ b/docs/artifacts/active/EXEC-20260530-provider-catalog.md
@@ -21,7 +21,7 @@ ontology_relations:
 | Date | 2026-05-30 |
 | Owner | Codex |
 | Related Artifacts | `docs/artifacts/active/CHARTER-20260530-provider-catalog.md`, `docs/artifacts/decisions/ADR-0001-provider-catalog.md`, `docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md`, `docs/artifacts/evidence/EVID-20260530-provider-catalog.md`, `docs/artifacts/memory/MEM-20260530-provider-catalog-implementation.md` |
-| Related Files | `src/bootstrap/provider_catalog.rs`, `src/bootstrap/provider_registry.rs`, `src/bootstrap/mod.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`, `README.md`, `docs/intro.md`, `docs/quickstart.md`, `docs/project/ARCHITECTURE.md`, `docs/architecture.md`, `HARNESS.md` |
+| Related Files | `src/bootstrap/provider_catalog.rs`, `src/bootstrap/provider_registry.rs`, `src/bootstrap/mod.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`, `README.md`, `CHANGELOG.md`, `docs/intro.md`, `docs/quickstart.md`, `docs/project/ARCHITECTURE.md`, `docs/architecture.md`, `HARNESS.md` |
 
 ## Starting Point
 
@@ -77,10 +77,18 @@ Implementation completed in this session. Evidence is recorded in `docs/artifact
 - Result: Completed.
 - Evidence: Created `docs/artifacts/evidence/EVID-20260530-provider-catalog.md` and `docs/artifacts/memory/MEM-20260530-provider-catalog-implementation.md`. `just check` passed outside the sandbox.
 
+### Step 7
+
+- Action: Add the assigned draft PR number to the changelog before marking the PR ready.
+- Files touched: `CHANGELOG.md`, `docs/artifacts/active/CHARTER-20260530-provider-catalog.md`, `docs/artifacts/active/EXEC-20260530-provider-catalog.md`, `docs/artifacts/evidence/EVID-20260530-provider-catalog.md`, `docs/artifacts/memory/MEM-20260530-provider-catalog-implementation.md`
+- Result: Completed.
+- Evidence: PR `#19` is now referenced in `CHANGELOG.md`; focused changelog and markdown checks passed; `just check` passed after the follow-up.
+
 ## Deviations From Charter
 
 - Rollback commit was not created. The worktree already had staged exploration artifacts and untracked provider-catalog planning artifacts before implementation started, so creating a rollback commit would have committed user-created work outside this execution scope.
 - The first `just check` run inside the sandbox failed in an existing HTTP unit test because sandbox permissions denied binding a local TCP listener. The same command was rerun outside the sandbox and passed.
+- The draft PR number was assigned after the implementation commit, so the `CHANGELOG.md` entry was added as a PR-readiness follow-up.
 
 ## Bugs Found
 
@@ -97,3 +105,5 @@ Implementation completed in this session. Evidence is recorded in `docs/artifact
 - Docs validation passed: `python3 scripts/check_markdown_frontmatter.py` and `mdbook build`.
 - Canonical gate passed outside the sandbox: `just check`.
 - Evidence pack documents the sandboxed `just check` failure and successful rerun.
+- `CHANGELOG.md` now references draft PR `#19`.
+- PR-readiness follow-up validation passed: `cargo test --test changelog_test`, `python3 scripts/check_markdown_frontmatter.py`, and `just check`.

--- a/docs/artifacts/active/EXEC-20260530-provider-catalog.md
+++ b/docs/artifacts/active/EXEC-20260530-provider-catalog.md
@@ -1,0 +1,99 @@
+---
+title: "Execution log: provider catalog"
+when_to_read:
+  - "When continuing or reviewing the provider catalog refactor execution."
+summary: "Tracks implementation steps, deviations, bugs, and evidence notes for the provider catalog refactor."
+ontology_relations:
+  - relation: "tracks"
+    target: "docs/artifacts/active/CHARTER-20260530-provider-catalog.md"
+    note: "Records execution against the active provider catalog charter."
+  - relation: "implements"
+    target: "docs/artifacts/decisions/ADR-0001-provider-catalog.md"
+    note: "Tracks work that applies the provider catalog ownership decision."
+---
+
+# Execution Log
+
+| Field | Value |
+|---|---|
+| Artifact Type | Execution Log |
+| Status | Completed |
+| Date | 2026-05-30 |
+| Owner | Codex |
+| Related Artifacts | `docs/artifacts/active/CHARTER-20260530-provider-catalog.md`, `docs/artifacts/decisions/ADR-0001-provider-catalog.md`, `docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md`, `docs/artifacts/evidence/EVID-20260530-provider-catalog.md`, `docs/artifacts/memory/MEM-20260530-provider-catalog-implementation.md` |
+| Related Files | `src/bootstrap/provider_catalog.rs`, `src/bootstrap/provider_registry.rs`, `src/bootstrap/mod.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`, `README.md`, `docs/intro.md`, `docs/quickstart.md`, `docs/project/ARCHITECTURE.md`, `docs/architecture.md`, `HARNESS.md` |
+
+## Starting Point
+
+- Current short commit when this log was created: `6c562b5`.
+- The worktree already contained artifact changes related to architecture/provider exploration before this plan was created.
+- No provider catalog implementation has started.
+- Current source has hardcoded provider identity and ordering in `src/bootstrap/provider_registry.rs`, `src/cli/args.rs`, and `src/cli/runner.rs`.
+- Current docs still describe provider registration through `src/bootstrap/provider_registry.rs`.
+
+## Timeline
+
+Implementation completed in this session. Evidence is recorded in `docs/artifacts/evidence/EVID-20260530-provider-catalog.md`.
+
+### Step 1
+
+- Action: Add failing-first catalog regression tests.
+- Files touched: `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`
+- Result: Completed.
+- Evidence: Initial run of `cargo test --test architecture_test test_provider_catalog_is_provider_wiring_source_of_truth` failed as expected because `src/bootstrap/provider_catalog.rs` did not exist. Final architecture, registry, and CLI integration tests passed.
+
+### Step 2
+
+- Action: Add provider catalog module and expose it from bootstrap.
+- Files touched: `src/bootstrap/provider_catalog.rs`, `src/bootstrap/mod.rs`
+- Result: Completed.
+- Evidence: `src/bootstrap/provider_catalog.rs` now defines `ProviderId`, `ProviderCatalogEntry`, `PROVIDER_CATALOG`, catalog lookup helpers, env-var hint formatting, display-name iteration, and Brave/Exa production builders. `src/bootstrap/mod.rs` exposes the module.
+
+### Step 3
+
+- Action: Refactor provider registry construction and ordering through the catalog.
+- Files touched: `src/bootstrap/provider_registry.rs`, `tests/integration/provider_registry_test.rs`
+- Result: Completed.
+- Evidence: `ProviderRegistry::production_from_env` iterates catalog entries, `available_providers` follows catalog order, and `cargo test --test provider_registry_integration` passed with 13 tests.
+
+### Step 4
+
+- Action: Refactor CLI provider parsing and runner selection through catalog-backed provider IDs.
+- Files touched: `src/cli/args.rs`, `src/cli/runner.rs`, `tests/integration/cli_test.rs`
+- Result: Completed.
+- Evidence: `CliProvider` is now `Single(ProviderId)` or `All`; parser resolves real provider tokens through the catalog and unknown tokens report valid catalog tokens plus `all`. `cargo test --test cli_integration` passed with 8 tests.
+
+### Step 5
+
+- Action: Clean up provider catalog docs.
+- Files touched: `README.md`, `docs/intro.md`, `docs/quickstart.md`, `docs/project/ARCHITECTURE.md`, `docs/architecture.md`, `docs/dependency-architecture-map.md`, `docs/dependency-architecture-map.html`, `HARNESS.md`
+- Result: Completed.
+- Evidence: Provider registration guidance now points at `src/bootstrap/provider_catalog.rs`; `python3 scripts/check_markdown_frontmatter.py` and `mdbook build` passed.
+
+### Step 6
+
+- Action: Run targeted checks and canonical validation, then create evidence and memory.
+- Files touched: `docs/artifacts/evidence/`, `docs/artifacts/memory/`
+- Result: Completed.
+- Evidence: Created `docs/artifacts/evidence/EVID-20260530-provider-catalog.md` and `docs/artifacts/memory/MEM-20260530-provider-catalog-implementation.md`. `just check` passed outside the sandbox.
+
+## Deviations From Charter
+
+- Rollback commit was not created. The worktree already had staged exploration artifacts and untracked provider-catalog planning artifacts before implementation started, so creating a rollback commit would have committed user-created work outside this execution scope.
+- The first `just check` run inside the sandbox failed in an existing HTTP unit test because sandbox permissions denied binding a local TCP listener. The same command was rerun outside the sandbox and passed.
+
+## Bugs Found
+
+- The sandboxed validation environment cannot run the existing local TCP-listener HTTP unit test.
+
+## Bugs Fixed
+
+- No product bug fix was needed for the sandbox bind failure; the canonical gate passed outside the sandbox.
+
+## Notes For Evidence Pack
+
+- Failing-first catalog regression captured before implementation.
+- Targeted tests passed: `cargo test --test architecture_test`, `cargo test --test provider_registry_integration`, `cargo test --test cli_integration`, and `cargo test cli::args`.
+- Docs validation passed: `python3 scripts/check_markdown_frontmatter.py` and `mdbook build`.
+- Canonical gate passed outside the sandbox: `just check`.
+- Evidence pack documents the sandboxed `just check` failure and successful rerun.

--- a/docs/artifacts/decisions/ADR-0001-provider-catalog.md
+++ b/docs/artifacts/decisions/ADR-0001-provider-catalog.md
@@ -1,0 +1,138 @@
+---
+title: "ADR-0001: Provider catalog"
+when_to_read:
+  - "When adding, removing, renaming, or wiring a search provider."
+  - "When changing CLI provider parsing, provider registry construction, or provider ordering."
+summary: "Records the decision that a bootstrap-owned provider catalog is the source of truth for provider identity, CLI tokens, display metadata, environment variables, stable ordering, and production construction."
+ontology_relations:
+  - relation: "decides"
+    target: "sophon-cli-provider-catalog"
+    note: "Establishes catalog ownership for provider identity and production wiring."
+  - relation: "informed_by"
+    target: "docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md"
+    note: "Uses the exploration that found live provider metadata duplication."
+  - relation: "implemented_by"
+    target: "docs/artifacts/active/CHARTER-20260530-provider-catalog.md"
+    note: "The active charter defines the implementation work for this decision."
+---
+
+# ADR-0001: Provider Catalog
+
+| Field | Value |
+|---|---|
+| Artifact Type | Decision Record |
+| Status | Active |
+| Date | 2026-05-30 |
+| Owner | Codex |
+| Related Artifacts | `docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md`, `docs/artifacts/memory/MEM-20260530-provider-catalog-research.md`, `docs/artifacts/active/CHARTER-20260530-provider-catalog.md` |
+| Related Files | `src/bootstrap/provider_registry.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`, `README.md`, `docs/intro.md`, `docs/quickstart.md`, `docs/project/ARCHITECTURE.md`, `docs/architecture.md`, `HARNESS.md` |
+
+## Context
+
+The current codebase repeats supported-provider knowledge across CLI parsing, CLI runner selection, bootstrap provider IDs, production provider construction, stable provider ordering, user-facing docs, maintainer docs, and tests.
+
+The focused exploration found that this repetition is live behavior, not dead code. Adding another provider would currently require editing several separate provider lists and matches. That raises the chance of adding a provider to one path while forgetting CLI parsing, fan-out ordering, unavailable-provider errors, or docs.
+
+## Decision
+
+Create a bootstrap-owned static ordered provider catalog. The catalog contains only real providers and is authoritative for:
+
+- provider id
+- CLI token
+- display name
+- environment variable name
+- stable provider order
+- production builder
+
+The CLI `all` option is not a catalog entry. It remains a CLI-only aggregate selection mode that asks the registry to build every environment-enabled provider in catalog order.
+
+CLI provider parsing must resolve real provider tokens through the catalog. Unknown provider tokens must fail gracefully at argument parse time and show valid catalog provider tokens plus `all`.
+
+Regression tests must protect this ownership model by requiring CLI and bootstrap provider wiring to use the catalog and by forbidding duplicated hardcoded provider identities in CLI/bootstrap source outside approved locations.
+
+## Rationale
+
+A static ordered catalog is simpler and more maintainable than scattered enum matches and arrays. Provider count is small, so a linear catalog scan is efficient enough and keeps ordering explicit.
+
+Keeping the catalog in bootstrap preserves the existing architecture: bootstrap owns concrete construction, provider adapters remain provider-specific, and the domain remains provider-agnostic.
+
+Keeping `all` out of the catalog avoids mixing real providers with CLI selection modes. This keeps env checks, construction, and ordering focused on actual provider entries.
+
+## Options Considered
+
+### Option A: Keep Current Explicit Matches
+
+Pros:
+
+- Minimal immediate code churn.
+- Current behavior is easy to inspect for two providers.
+
+Cons:
+
+- Provider identity and ordering stay duplicated.
+- Adding a provider remains a multi-surface edit with weak locality.
+- Tests can prove behavior but not ownership of provider metadata.
+
+### Option B: Static Bootstrap Provider Catalog
+
+Pros:
+
+- One authoritative source for provider identity, order, env metadata, and construction.
+- Efficient enough for the small provider set.
+- Preserves current layer boundaries.
+- Makes provider addition work easier to explain and test.
+
+Cons:
+
+- Requires replacing `clap::ValueEnum` provider parsing with catalog-backed parsing.
+- Requires careful source-scan exemptions so provider adapter internals and docs are not over-constrained.
+
+### Option C: Dynamic Runtime Provider Registry Only
+
+Pros:
+
+- Could support plugin-like provider discovery later.
+
+Cons:
+
+- More machinery than the current product needs.
+- Makes stable order and graceful help/error text harder to reason about.
+- Risks obscuring the simple built-in provider model.
+
+## Consequences
+
+### Positive
+
+- Provider additions get one main registration path.
+- Stable provider order becomes catalog declaration order.
+- CLI parsing, registry construction, and tests can share provider metadata.
+- Architecture tests can protect against provider-list drift.
+
+### Negative
+
+- The CLI layer will intentionally depend on the bootstrap catalog for provider token parsing.
+- The provider parsing implementation must preserve or replace the helpful errors previously supplied by `clap::ValueEnum`.
+
+### Neutral / Operational
+
+- User-facing docs may still mention supported providers explicitly, but maintainer docs must point provider registration work to the catalog.
+- Provider adapters can still return provider strings in mapped domain responses; this ADR governs provider wiring metadata, not every provider name literal.
+
+## Constraints Created
+
+- Real provider identity, CLI tokens, display names, env var names, stable order, and production builders must be added to the provider catalog.
+- `all` must remain a CLI aggregate mode and must not be represented as a real provider catalog entry.
+- Provider-specific DTOs, request rules, and config loading stay in provider modules.
+- Domain types must remain provider-agnostic.
+- CLI/bootstrap code must not maintain a second hardcoded list of real providers.
+
+## Evidence
+
+- `docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md` maps the duplicated provider metadata.
+- `docs/artifacts/memory/MEM-20260530-provider-catalog-research.md` summarizes the exploration session.
+- `docs/artifacts/active/CHARTER-20260530-provider-catalog.md` defines the execution plan.
+- Future implementation evidence must be captured in `docs/artifacts/evidence/`.
+
+## Revisit Trigger
+
+Revisit this decision if providers become dynamically loaded, if provider configuration no longer comes from environment-backed built-ins, or if CLI provider selection needs to support provider groups beyond `all`.

--- a/docs/artifacts/evidence/EVID-20260530-provider-catalog.md
+++ b/docs/artifacts/evidence/EVID-20260530-provider-catalog.md
@@ -22,7 +22,7 @@ ontology_relations:
 | Date | 2026-05-30 |
 | Owner | Codex |
 | Related Artifacts | `docs/artifacts/active/CHARTER-20260530-provider-catalog.md`, `docs/artifacts/active/EXEC-20260530-provider-catalog.md`, `docs/artifacts/decisions/ADR-0001-provider-catalog.md` |
-| Related Files | `src/bootstrap/provider_catalog.rs`, `src/bootstrap/provider_registry.rs`, `src/bootstrap/mod.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`, `README.md`, `docs/intro.md`, `docs/quickstart.md`, `docs/project/ARCHITECTURE.md`, `docs/architecture.md`, `docs/dependency-architecture-map.md`, `docs/dependency-architecture-map.html`, `HARNESS.md` |
+| Related Files | `src/bootstrap/provider_catalog.rs`, `src/bootstrap/provider_registry.rs`, `src/bootstrap/mod.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`, `README.md`, `CHANGELOG.md`, `docs/intro.md`, `docs/quickstart.md`, `docs/project/ARCHITECTURE.md`, `docs/architecture.md`, `docs/dependency-architecture-map.md`, `docs/dependency-architecture-map.html`, `HARNESS.md` |
 
 ## Claim Being Proven
 
@@ -40,6 +40,7 @@ Provider identity, CLI token lookup, display names, environment variable names, 
 - `tests/architecture_test.rs`
 - `tests/integration/provider_registry_test.rs`
 - `tests/integration/cli_test.rs`
+- `CHANGELOG.md`
 - `README.md`
 - `docs/intro.md`
 - `docs/quickstart.md`
@@ -58,6 +59,7 @@ Provider identity, CLI token lookup, display names, environment variable names, 
 - Updated `src/cli/runner.rs` to run `CliProvider::Single(ProviderId)` directly and render about text from catalog display names.
 - Added architecture and integration tests for catalog ownership, catalog metadata, CLI token parsing, and unknown-provider errors.
 - Updated README, mdBook docs, project architecture docs, dependency map docs, and harness source index to point provider registration at the catalog.
+- Added draft PR `#19` to `CHANGELOG.md` so the merged-PR coverage test remains satisfied after the PR lands.
 
 ## Commands Run
 
@@ -75,6 +77,9 @@ python3 scripts/check_markdown_frontmatter.py
 mdbook build
 cargo fmt --check
 cargo run -- --help
+cargo test --test changelog_test
+python3 scripts/check_markdown_frontmatter.py
+just check
 just check
 just check
 rg -n 'BraveConfig::from_env|ExaConfig::from_env|BraveProvider::new|ExaProvider::new|BRAVE_API_KEY|EXA_API_KEY' src/bootstrap -g '*.rs'
@@ -96,6 +101,9 @@ rg -n 'ProviderId::Brave|ProviderId::Exa' src/cli/runner.rs src/cli/args.rs
 | mdBook | `mdbook build` | Passed | HTML written to `book`. |
 | Formatting | `cargo fmt --check` | Passed | No output. |
 | CLI help provider values | `cargo run -- --help` | Passed | Help lists `[possible values: brave, exa, all]` for `--provider`. |
+| Changelog coverage | `cargo test --test changelog_test` | Passed | Passes after adding draft PR `#19` to `CHANGELOG.md`; local GitHub API fetch is skipped if unavailable outside CI. |
+| Markdown frontmatter, PR-readiness follow-up | `python3 scripts/check_markdown_frontmatter.py` | Passed | Confirms the artifact updates still satisfy tracked Markdown frontmatter requirements. |
+| Canonical gate, PR-readiness follow-up | `just check` | Passed | `cargo fmt --check`, clippy, all tests, changelog coverage, frontmatter, and mdBook passed after the changelog entry was added. |
 | Canonical gate, sandboxed | `just check` | Failed for environment reason | `cargo test` failed in `transport::http::tests::test_post_json_decodes_success_response` because sandboxing denied binding `127.0.0.1:0`. |
 | Canonical gate, outside sandbox | `just check` | Passed | `cargo fmt --check`, clippy, all tests, frontmatter, and mdBook passed. |
 | Bootstrap wiring source scan | `rg ... src/bootstrap -g '*.rs'` | Passed with expected locations | Provider construction/env strings are in `provider_catalog.rs`; remaining env strings in `provider_registry.rs` are test-only fixtures. |
@@ -108,6 +116,7 @@ rg -n 'ProviderId::Brave|ProviderId::Exa' src/cli/runner.rs src/cli/args.rs
 2. Reviewed CLI parsing to confirm `CliProvider` has only `Single(ProviderId)` and `All`; real providers are not duplicated as CLI enum variants.
 3. Reviewed `--help` output to confirm provider possible values still come from the catalog-backed parser.
 4. Reviewed docs search results for stale provider-registration guidance and updated the mdBook dependency map that is embedded in docs.
+5. Reviewed draft PR `#19` metadata and added the assigned PR number to `CHANGELOG.md` before marking the PR ready.
 
 ## Logs / Output
 

--- a/docs/artifacts/evidence/EVID-20260530-provider-catalog.md
+++ b/docs/artifacts/evidence/EVID-20260530-provider-catalog.md
@@ -1,0 +1,145 @@
+---
+title: "Evidence: provider catalog"
+when_to_read:
+  - "When verifying the provider catalog refactor implementation."
+  - "When checking why provider catalog execution was considered complete."
+summary: "Evidence that provider identity, CLI parsing, production provider wiring, stable ordering, and docs now route through the bootstrap provider catalog."
+ontology_relations:
+  - relation: "supports"
+    target: "docs/artifacts/active/CHARTER-20260530-provider-catalog.md"
+    note: "Provides validation evidence for the provider catalog session charter."
+  - relation: "implements"
+    target: "docs/artifacts/decisions/ADR-0001-provider-catalog.md"
+    note: "Shows the durable provider catalog decision was applied in code, tests, and docs."
+---
+
+# Evidence Pack
+
+| Field | Value |
+|---|---|
+| Artifact Type | Evidence Pack |
+| Status | Completed |
+| Date | 2026-05-30 |
+| Owner | Codex |
+| Related Artifacts | `docs/artifacts/active/CHARTER-20260530-provider-catalog.md`, `docs/artifacts/active/EXEC-20260530-provider-catalog.md`, `docs/artifacts/decisions/ADR-0001-provider-catalog.md` |
+| Related Files | `src/bootstrap/provider_catalog.rs`, `src/bootstrap/provider_registry.rs`, `src/bootstrap/mod.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`, `README.md`, `docs/intro.md`, `docs/quickstart.md`, `docs/project/ARCHITECTURE.md`, `docs/architecture.md`, `docs/dependency-architecture-map.md`, `docs/dependency-architecture-map.html`, `HARNESS.md` |
+
+## Claim Being Proven
+
+Provider identity, CLI token lookup, display names, environment variable names, stable ordering, and production construction are now sourced from a bootstrap provider catalog. `all` remains a CLI-only aggregate mode, and the registry plus CLI no longer maintain independent real-provider wiring lists.
+
+## Files Reviewed
+
+- `docs/artifacts/active/CHARTER-20260530-provider-catalog.md`
+- `docs/artifacts/active/EXEC-20260530-provider-catalog.md`
+- `docs/artifacts/decisions/ADR-0001-provider-catalog.md`
+- `src/bootstrap/provider_registry.rs`
+- `src/bootstrap/mod.rs`
+- `src/cli/args.rs`
+- `src/cli/runner.rs`
+- `tests/architecture_test.rs`
+- `tests/integration/provider_registry_test.rs`
+- `tests/integration/cli_test.rs`
+- `README.md`
+- `docs/intro.md`
+- `docs/quickstart.md`
+- `docs/project/ARCHITECTURE.md`
+- `docs/architecture.md`
+- `docs/dependency-architecture-map.md`
+- `docs/dependency-architecture-map.html`
+- `HARNESS.md`
+
+## Files Changed
+
+- Added `src/bootstrap/provider_catalog.rs` with `ProviderId`, `ProviderCatalogEntry`, the ordered `PROVIDER_CATALOG`, catalog lookup helpers, env-var hint formatting, display-name iteration, and production builders for Brave and Exa.
+- Updated `src/bootstrap/provider_registry.rs` to iterate catalog entries for production registration and available-provider order.
+- Updated `src/bootstrap/mod.rs` to expose `provider_catalog`.
+- Updated `src/cli/args.rs` so real provider tokens parse through the catalog, while `all` remains CLI-only.
+- Updated `src/cli/runner.rs` to run `CliProvider::Single(ProviderId)` directly and render about text from catalog display names.
+- Added architecture and integration tests for catalog ownership, catalog metadata, CLI token parsing, and unknown-provider errors.
+- Updated README, mdBook docs, project architecture docs, dependency map docs, and harness source index to point provider registration at the catalog.
+
+## Commands Run
+
+```bash
+cargo test --test architecture_test test_provider_catalog_is_provider_wiring_source_of_truth
+cargo test --test architecture_test test_provider_catalog_is_provider_wiring_source_of_truth
+cargo test --test provider_registry_integration
+cargo test --test cli_integration
+cargo test cli::args
+cargo fmt
+cargo test --test architecture_test
+cargo test --test provider_registry_integration
+cargo test --test cli_integration
+python3 scripts/check_markdown_frontmatter.py
+mdbook build
+cargo fmt --check
+cargo run -- --help
+just check
+just check
+rg -n 'BraveConfig::from_env|ExaConfig::from_env|BraveProvider::new|ExaProvider::new|BRAVE_API_KEY|EXA_API_KEY' src/bootstrap -g '*.rs'
+rg -n 'CliProvider::Brave|CliProvider::Exa' src/cli -g '*.rs'
+rg -n 'ProviderId::Brave|ProviderId::Exa' src/cli/runner.rs src/cli/args.rs
+```
+
+## Test Results
+
+| Check | Command / Method | Result | Notes |
+|---|---|---|---|
+| Failing-first catalog regression | `cargo test --test architecture_test test_provider_catalog_is_provider_wiring_source_of_truth` before implementation | Failed as expected | Failed because `src/bootstrap/provider_catalog.rs` did not exist. |
+| Catalog regression after implementation | `cargo test --test architecture_test test_provider_catalog_is_provider_wiring_source_of_truth` | Passed | Proves source-scan guardrail is active. |
+| Architecture tests | `cargo test --test architecture_test` | Passed | 13 passed. |
+| Provider registry integration | `cargo test --test provider_registry_integration` | Passed | 13 passed. |
+| CLI integration | `cargo test --test cli_integration` | Passed | 8 passed. |
+| CLI args unit filter | `cargo test cli::args` | Passed | 3 CLI provider parsing tests passed. |
+| Markdown frontmatter | `python3 scripts/check_markdown_frontmatter.py` | Passed | No output. |
+| mdBook | `mdbook build` | Passed | HTML written to `book`. |
+| Formatting | `cargo fmt --check` | Passed | No output. |
+| CLI help provider values | `cargo run -- --help` | Passed | Help lists `[possible values: brave, exa, all]` for `--provider`. |
+| Canonical gate, sandboxed | `just check` | Failed for environment reason | `cargo test` failed in `transport::http::tests::test_post_json_decodes_success_response` because sandboxing denied binding `127.0.0.1:0`. |
+| Canonical gate, outside sandbox | `just check` | Passed | `cargo fmt --check`, clippy, all tests, frontmatter, and mdBook passed. |
+| Bootstrap wiring source scan | `rg ... src/bootstrap -g '*.rs'` | Passed with expected locations | Provider construction/env strings are in `provider_catalog.rs`; remaining env strings in `provider_registry.rs` are test-only fixtures. |
+| CLI duplicate provider mode scan | `rg -n 'CliProvider::Brave|CliProvider::Exa' src/cli -g '*.rs'` | Passed | No matches. |
+| CLI runner provider-id scan | `rg -n 'ProviderId::Brave|ProviderId::Exa' src/cli/runner.rs src/cli/args.rs` | Passed with expected test-only matches | Matches only in `src/cli/args.rs` unit tests, not runner implementation. |
+
+## Manual Verification
+
+1. Reviewed the final diff to confirm `ProviderRegistry::production_from_env` iterates `provider_catalog::provider_catalog()`.
+2. Reviewed CLI parsing to confirm `CliProvider` has only `Single(ProviderId)` and `All`; real providers are not duplicated as CLI enum variants.
+3. Reviewed `--help` output to confirm provider possible values still come from the catalog-backed parser.
+4. Reviewed docs search results for stale provider-registration guidance and updated the mdBook dependency map that is embedded in docs.
+
+## Logs / Output
+
+```text
+pre-implementation regression:
+test_provider_catalog_is_provider_wiring_source_of_truth ... FAILED
+provider identity and production wiring must live in src/bootstrap/provider_catalog.rs
+
+canonical gate outside sandbox:
+just check
+...
+test result: ok. 29 passed; 0 failed
+...
+test result: ok. 13 passed; 0 failed
+...
+test result: ok. 8 passed; 0 failed
+...
+python3 scripts/check_markdown_frontmatter.py
+mdbook build
+INFO HTML book written to `/Users/tuna/sophon/book`
+```
+
+## Screenshots / Visual Evidence
+
+Not applicable. This change is CLI/library behavior and documentation text, not a visual UI.
+
+## Known Gaps
+
+- No live Brave or Exa API calls were run; live provider calls remain outside automated evidence.
+- The catalog source-scan deliberately allows provider tokens and env-var strings in provider config modules, the catalog, and test fixtures.
+- The sandboxed `just check` cannot prove the local TCP-listener HTTP unit test because sandbox permissions deny the bind operation; the same canonical gate passed outside the sandbox.
+
+## Final Evidence Judgment
+
+Proven. The failing-first ownership regression was captured, the catalog-backed implementation is covered by architecture and integration tests, documentation was updated, and the canonical `just check` gate passed outside the sandbox.

--- a/docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md
+++ b/docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md
@@ -1,0 +1,118 @@
+---
+title: "Exploration: Provider catalog duplication"
+when_to_read:
+  - "When evaluating provider registry, CLI provider selection, or adding a provider to sophon-cli."
+  - "Before creating a charter for a provider catalog or provider registry refactor."
+summary: "Maps where supported-provider knowledge is currently repeated across CLI, bootstrap, provider config, docs, and tests."
+ontology_relations:
+  - relation: "explores"
+    target: "sophon-cli-provider-catalog-duplication"
+    note: "Captures factual research about duplicated provider metadata before any refactor charter."
+  - relation: "relates_to"
+    target: "docs/artifacts/explorations/EXP-20260530-maintainability-optimization.md"
+    note: "Deepens Candidate 3 from the broader maintainability exploration."
+---
+
+# Exploration Memory
+
+| Field | Value |
+|---|---|
+| Artifact Type | Exploration Memory |
+| Status | Active |
+| Date | 2026-05-30 |
+| Owner | Codex |
+| Related Artifacts | `docs/artifacts/explorations/EXP-20260530-maintainability-optimization.md` |
+| Related Files | `src/bootstrap/provider_registry.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `src/providers/brave/config.rs`, `src/providers/exa/config.rs`, `tests/integration/provider_registry_test.rs`, `tests/architecture_test.rs`, `docs/project/ARCHITECTURE.md`, `README.md` |
+
+## Research Intent
+
+Research type: `explore`
+
+Commitment status: `decision-support`
+
+Goal: map where the repository currently states which search providers exist, how those facts connect at runtime, and what files currently encode provider ordering, env configuration, and CLI selection.
+
+Out of scope:
+
+- Implementing a provider catalog.
+- Adding a provider.
+- Changing CLI behavior, output, errors, or provider order.
+- Deciding the final refactor shape.
+
+## Question
+
+Where does the codebase currently say "the supported providers are Brave and Exa," and is that repetition dead code or live behavior?
+
+## Short Answer
+
+No dead provider-selection code was found in this path. The repeated provider facts are live runtime and test behavior.
+
+The smell is that provider identity, CLI selection, display text, environment-backed construction, stable ordering, and tests each encode overlapping knowledge of Brave and Exa.
+
+## Runtime Path
+
+- `src/cli/args.rs:42` defines `CliProvider` with `Brave`, `Exa`, and `All`.
+- `src/cli/runner.rs:29` creates `ProviderRegistry::production_from_env()` during normal CLI execution.
+- `src/cli/runner.rs:31` branches on the parsed `CliProvider`.
+- `src/cli/runner.rs:32` maps `CliProvider::Brave` to `ProviderId::Brave`.
+- `src/cli/runner.rs:33` maps `CliProvider::Exa` to `ProviderId::Exa`.
+- `src/cli/runner.rs:34` maps `CliProvider::All` to all enabled providers through the registry.
+- `src/bootstrap/provider_registry.rs:51` builds the production registry from environment variables.
+- `src/bootstrap/provider_registry.rs:54` reads Brave config and registers a Brave provider builder when configured.
+- `src/bootstrap/provider_registry.rs:66` reads Exa config and registers an Exa provider builder when configured.
+- `src/bootstrap/provider_registry.rs:103` builds a fan-out service from every available provider.
+
+## Duplication Map
+
+| Provider Fact | Current Locations | Observed Role |
+|---|---|---|
+| Provider IDs | `src/bootstrap/provider_registry.rs:13`, `src/cli/args.rs:42` | Bootstrap and CLI each define provider choices in local enums. |
+| Provider display strings | `src/bootstrap/provider_registry.rs:18`, `src/cli/runner.rs:46`, `README.md:7`, `README.md:40`, `README.md:43` | Error/log formatting, about text, and docs each name Brave and Exa. |
+| Env var names | `src/providers/brave/config.rs:9`, `src/providers/exa/config.rs:9`, `src/bootstrap/provider_registry.rs:40`, `README.md:40`, `README.md:43`, `tests/integration/provider_registry_test.rs:47` | Config loading, user docs, error text, and tests repeat `BRAVE_API_KEY` and `EXA_API_KEY`. |
+| Provider construction | `src/bootstrap/provider_registry.rs:54`, `src/bootstrap/provider_registry.rs:66` | Production bootstrap knows which config type and client type construct each provider. |
+| Stable provider order | `src/bootstrap/provider_registry.rs:85`, `tests/integration/provider_registry_test.rs:148`, `tests/integration/provider_registry_test.rs:245` | The order `Brave`, then `Exa`, is encoded by the registry and asserted by tests. |
+| CLI-to-bootstrap mapping | `src/cli/runner.rs:31` | Parsed CLI provider values are translated to bootstrap provider IDs. |
+| Provider registration documentation | `docs/project/ARCHITECTURE.md:91` | Project docs identify `src/bootstrap/provider_registry.rs` as the preferred provider registration location. |
+| Architecture import contract | `tests/architecture_test.rs:93` | The architecture test expects `runner.rs` to use `CliProvider`, `ProviderRegistry`, and `ProviderId`. |
+
+## Current Change Surface For A Third Provider
+
+Based on the current shape, adding a third provider would touch at least these surfaces:
+
+- Provider adapter files under `src/providers/<provider>/`.
+- Config loading for the provider-specific API key.
+- `ProviderId` in `src/bootstrap/provider_registry.rs:13`.
+- `Display for ProviderId` in `src/bootstrap/provider_registry.rs:18`.
+- `ProviderRegistry::production_from_env` in `src/bootstrap/provider_registry.rs:51`.
+- Stable ordering in `ProviderRegistry::available_providers` at `src/bootstrap/provider_registry.rs:85`.
+- `CliProvider` in `src/cli/args.rs:42`.
+- Provider branching in `src/cli/runner.rs:31`.
+- About text in `src/cli/runner.rs:46`.
+- Registry tests in `tests/integration/provider_registry_test.rs:148` and `tests/integration/provider_registry_test.rs:245`.
+- CLI parsing tests in `src/cli/args.rs:85` and `tests/integration/cli_test.rs:85`.
+- User and project docs that list supported providers or env vars.
+
+## Test Coverage Found
+
+- Empty registry behavior is tested in `tests/integration/provider_registry_test.rs:105` and `tests/integration/provider_registry_test.rs:125`.
+- Manual provider registration is tested in `tests/integration/provider_registry_test.rs:139`.
+- Stable provider order is tested in `tests/integration/provider_registry_test.rs:147` and `tests/integration/provider_registry_test.rs:244`.
+- Env-backed registry construction is tested for no keys, empty keys, Brave-only, Exa-only, and both providers in `tests/integration/provider_registry_test.rs:159`.
+- Explicit unavailable-provider errors are tested in `tests/integration/provider_registry_test.rs:207`.
+- CLI provider parsing for `exa`, `all`, and default `brave` is tested in `src/cli/args.rs:85`.
+- The architecture test records a current dependency expectation from CLI runner to bootstrap provider IDs in `tests/architecture_test.rs:93`.
+
+## Boundary Facts
+
+- `docs/project/ARCHITECTURE.md:87` says new provider API mapping belongs under `src/providers/<provider>/`.
+- `docs/project/ARCHITECTURE.md:89` says CLI flag or command behavior belongs under `src/cli/args.rs`, `src/cli/request.rs`, and `src/cli/runner.rs`.
+- `docs/project/ARCHITECTURE.md:91` says provider registration belongs in `src/bootstrap/provider_registry.rs`.
+- `src/bootstrap/provider_registry.rs:4` imports app services.
+- `src/bootstrap/provider_registry.rs:5` imports the domain provider trait.
+- `src/bootstrap/provider_registry.rs:6` imports concrete provider adapters and configs.
+- `src/bootstrap/provider_registry.rs:10` imports the HTTP transport adapter.
+- `src/cli/runner.rs:3` imports `ProviderId` and `ProviderRegistry` from bootstrap.
+
+## Conclusion
+
+The duplicated provider knowledge is live, tested behavior. The current shape is understandable for two providers, but the same facts are repeated across CLI parsing, bootstrap IDs, display text, env-backed construction, stable ordering, docs, and tests. This supports the earlier "Worth exploring" classification for a provider catalog, without deciding that a catalog should be implemented.

--- a/docs/artifacts/memory/MEM-20260530-provider-catalog-implementation.md
+++ b/docs/artifacts/memory/MEM-20260530-provider-catalog-implementation.md
@@ -1,0 +1,75 @@
+---
+title: "Session memory: provider catalog implementation"
+when_to_read:
+  - "When continuing after the provider catalog implementation session."
+  - "When adding or changing a search provider after the provider catalog refactor."
+summary: "Records the implementation session that moved provider identity, CLI token parsing, stable ordering, env-var metadata, and production construction into the bootstrap provider catalog."
+ontology_relations:
+  - relation: "summarizes"
+    target: "docs/artifacts/active/CHARTER-20260530-provider-catalog.md"
+    note: "Captures the completed execution session for the active provider catalog charter."
+  - relation: "supported_by"
+    target: "docs/artifacts/evidence/EVID-20260530-provider-catalog.md"
+    note: "Points to the validation evidence for this implementation session."
+  - relation: "implements"
+    target: "docs/artifacts/decisions/ADR-0001-provider-catalog.md"
+    note: "Records that ADR-0001 was applied in code, tests, and docs."
+---
+
+# Session Memory
+
+| Field | Value |
+|---|---|
+| Artifact Type | Session Memory |
+| Status | Completed |
+| Date | 2026-05-30 |
+| Owner | Codex |
+| Related Artifacts | `docs/artifacts/active/CHARTER-20260530-provider-catalog.md`, `docs/artifacts/active/EXEC-20260530-provider-catalog.md`, `docs/artifacts/decisions/ADR-0001-provider-catalog.md`, `docs/artifacts/evidence/EVID-20260530-provider-catalog.md` |
+| Related Files | `src/bootstrap/provider_catalog.rs`, `src/bootstrap/provider_registry.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`, `README.md`, `docs/architecture.md`, `docs/dependency-architecture-map.md`, `docs/dependency-architecture-map.html`, `docs/intro.md`, `docs/project/ARCHITECTURE.md`, `docs/quickstart.md`, `HARNESS.md` |
+
+## Decisions
+
+- Applied ADR-0001: real provider identity, display names, env vars, stable order, CLI tokens, and production builders now live in `src/bootstrap/provider_catalog.rs`.
+- Kept `all` out of the catalog. It remains `CliProvider::All`, a CLI-only aggregate mode.
+- Kept a compatibility re-export of `ProviderId` and `ProviderBuilder` from `provider_registry.rs` while making their defining surface the catalog.
+- Preserved the existing default-provider behavior by deriving it from the first catalog entry, currently Brave.
+
+## Constraints
+
+- No production code changed before the failing catalog ownership regression was added and captured.
+- Domain, app, provider, transport, bootstrap, and CLI layer boundaries remain enforced by `tests/architecture_test.rs`.
+- Provider-specific config loading stays in `src/providers/<provider>/config.rs`; the catalog calls those config loaders for production builders.
+- A rollback commit was not created because the worktree already contained staged and untracked user artifacts. Creating one would have committed user-created work outside this execution scope.
+
+## Files Changed
+
+- `src/bootstrap/provider_catalog.rs`: new ordered catalog and provider construction surface.
+- `src/bootstrap/provider_registry.rs`: registry now consumes catalog entries for env-backed registration and provider order.
+- `src/cli/args.rs`: `CliProvider` is now `Single(ProviderId)` or `All`; real provider parsing resolves through the catalog.
+- `src/cli/runner.rs`: single-provider selection uses the parsed catalog-backed provider ID; about text uses catalog display names.
+- `tests/architecture_test.rs`: new guardrail proves the catalog is the provider wiring source of truth.
+- `tests/integration/provider_registry_test.rs`: new catalog metadata assertions.
+- `tests/integration/cli_test.rs`: new parse-time unknown-provider and real-token assertions.
+- Docs and harness files: provider registration guidance now points at `src/bootstrap/provider_catalog.rs`.
+
+## Evidence / Tests
+
+- Evidence pack: `docs/artifacts/evidence/EVID-20260530-provider-catalog.md`.
+- Failing-first regression was captured before implementation.
+- Focused tests passed: `cargo test --test architecture_test`, `cargo test --test provider_registry_integration`, `cargo test --test cli_integration`, and `cargo test cli::args`.
+- Docs checks passed: `python3 scripts/check_markdown_frontmatter.py` and `mdbook build`.
+- Canonical gate passed outside the sandbox: `just check`.
+
+## Open Issues
+
+- The sandboxed `just check` fails in an existing HTTP unit test because the sandbox denies binding a local TCP listener. The same command passes outside the sandbox.
+- No live Brave or Exa API calls were run.
+- Existing staged exploration artifacts and untracked provider-catalog planning artifacts predated the implementation; they were left in place.
+- `scripts/__pycache__/` is still untracked and was not removed because it was unrelated generated output.
+
+## Future Agent Notes
+
+- Add a real provider by editing `src/bootstrap/provider_catalog.rs` first, then provider-specific config/client/mapper modules and tests.
+- Do not add real provider variants to `CliProvider`; keep it as `Single(ProviderId)` plus CLI-only aggregate modes.
+- If changing provider order, change the catalog order and update catalog/registry expectations together.
+- `ProviderRegistry` should stay a registry/composition consumer of catalog entries, not the owner of provider identity.

--- a/docs/artifacts/memory/MEM-20260530-provider-catalog-implementation.md
+++ b/docs/artifacts/memory/MEM-20260530-provider-catalog-implementation.md
@@ -3,7 +3,7 @@ title: "Session memory: provider catalog implementation"
 when_to_read:
   - "When continuing after the provider catalog implementation session."
   - "When adding or changing a search provider after the provider catalog refactor."
-summary: "Records the implementation session that moved provider identity, CLI token parsing, stable ordering, env-var metadata, and production construction into the bootstrap provider catalog."
+summary: "Records the implementation session that moved provider identity, CLI token parsing, stable ordering, env-var metadata, production construction, and the PR changelog reference into the bootstrap provider catalog work."
 ontology_relations:
   - relation: "summarizes"
     target: "docs/artifacts/active/CHARTER-20260530-provider-catalog.md"
@@ -25,7 +25,7 @@ ontology_relations:
 | Date | 2026-05-30 |
 | Owner | Codex |
 | Related Artifacts | `docs/artifacts/active/CHARTER-20260530-provider-catalog.md`, `docs/artifacts/active/EXEC-20260530-provider-catalog.md`, `docs/artifacts/decisions/ADR-0001-provider-catalog.md`, `docs/artifacts/evidence/EVID-20260530-provider-catalog.md` |
-| Related Files | `src/bootstrap/provider_catalog.rs`, `src/bootstrap/provider_registry.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`, `README.md`, `docs/architecture.md`, `docs/dependency-architecture-map.md`, `docs/dependency-architecture-map.html`, `docs/intro.md`, `docs/project/ARCHITECTURE.md`, `docs/quickstart.md`, `HARNESS.md` |
+| Related Files | `src/bootstrap/provider_catalog.rs`, `src/bootstrap/provider_registry.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `tests/architecture_test.rs`, `tests/integration/provider_registry_test.rs`, `tests/integration/cli_test.rs`, `README.md`, `CHANGELOG.md`, `docs/architecture.md`, `docs/dependency-architecture-map.md`, `docs/dependency-architecture-map.html`, `docs/intro.md`, `docs/project/ARCHITECTURE.md`, `docs/quickstart.md`, `HARNESS.md` |
 
 ## Decisions
 
@@ -33,6 +33,7 @@ ontology_relations:
 - Kept `all` out of the catalog. It remains `CliProvider::All`, a CLI-only aggregate mode.
 - Kept a compatibility re-export of `ProviderId` and `ProviderBuilder` from `provider_registry.rs` while making their defining surface the catalog.
 - Preserved the existing default-provider behavior by deriving it from the first catalog entry, currently Brave.
+- Added draft PR `#19` to `CHANGELOG.md` before marking the PR ready.
 
 ## Constraints
 
@@ -50,6 +51,7 @@ ontology_relations:
 - `tests/architecture_test.rs`: new guardrail proves the catalog is the provider wiring source of truth.
 - `tests/integration/provider_registry_test.rs`: new catalog metadata assertions.
 - `tests/integration/cli_test.rs`: new parse-time unknown-provider and real-token assertions.
+- `CHANGELOG.md`: added PR `#19` to the Unreleased provider catalog entry.
 - Docs and harness files: provider registration guidance now points at `src/bootstrap/provider_catalog.rs`.
 
 ## Evidence / Tests
@@ -58,6 +60,7 @@ ontology_relations:
 - Failing-first regression was captured before implementation.
 - Focused tests passed: `cargo test --test architecture_test`, `cargo test --test provider_registry_integration`, `cargo test --test cli_integration`, and `cargo test cli::args`.
 - Docs checks passed: `python3 scripts/check_markdown_frontmatter.py` and `mdbook build`.
+- Changelog follow-up checks passed: `cargo test --test changelog_test`, `python3 scripts/check_markdown_frontmatter.py`, and `just check`.
 - Canonical gate passed outside the sandbox: `just check`.
 
 ## Open Issues

--- a/docs/artifacts/memory/MEM-20260530-provider-catalog-research.md
+++ b/docs/artifacts/memory/MEM-20260530-provider-catalog-research.md
@@ -1,0 +1,51 @@
+---
+title: "Session memory: provider catalog duplication research"
+when_to_read:
+  - "When continuing after the provider catalog duplication exploration for sophon-cli."
+summary: "Summarizes the exploration-only research that mapped repeated provider metadata across CLI, bootstrap, provider config, docs, and tests."
+ontology_relations:
+  - relation: "summarizes"
+    target: "docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md"
+    note: "Records the session that created the focused provider catalog duplication exploration artifact."
+---
+
+# Session Memory
+
+| Field | Value |
+|---|---|
+| Artifact Type | Session Memory |
+| Status | Completed |
+| Date | 2026-05-30 |
+| Owner | Codex |
+| Related Artifacts | `docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md`, `docs/artifacts/explorations/EXP-20260530-maintainability-optimization.md` |
+| Related Files | `src/bootstrap/provider_registry.rs`, `src/cli/args.rs`, `src/cli/runner.rs`, `src/providers/brave/config.rs`, `src/providers/exa/config.rs`, `tests/integration/provider_registry_test.rs`, `tests/architecture_test.rs`, `docs/project/ARCHITECTURE.md`, `README.md` |
+
+## Decisions
+
+- No durable architecture decision was made.
+- No implementation work was started.
+- The session stayed in Exploration mode and focused only on mapping the provider metadata duplication smell.
+
+## Files Changed
+
+- `docs/artifacts/explorations/EXP-20260530-provider-catalog-duplication.md`: added focused research on repeated provider facts and current change surfaces.
+- `docs/artifacts/memory/MEM-20260530-provider-catalog-research.md`: added this session memory.
+
+## Evidence / Validation
+
+- Read repository process docs: `docs/artifacts/INDEX.md`, `docs/process/RULES.md`, and `docs/process/WORKFLOW.md`.
+- Read existing context: `docs/artifacts/explorations/EXP-20260530-maintainability-optimization.md`, `docs/artifacts/memory/MEM-20260530-architecture-optimization-exploration.md`, and `docs/project/PROJECT_CONTEXT.md`.
+- Reviewed source and test files for provider identity, CLI provider parsing, env-backed registry construction, stable provider order, and architecture contracts.
+- Ran direct frontmatter validation for the two new untracked artifacts; it passed.
+- Ran `python3 scripts/check_markdown_frontmatter.py`; it passed for tracked Markdown.
+- Ran `just check`; it passed, including `cargo fmt --check`, clippy, `cargo test`, tracked Markdown frontmatter validation, and `mdbook build`.
+
+## Open Issues
+
+- No code issue was resolved in this session.
+- A future implementation still requires a charter before source edits.
+
+## Future Agent Notes
+
+- The research found live duplication, not dead code.
+- The focused exploration is a companion to Candidate 3 in `docs/artifacts/explorations/EXP-20260530-maintainability-optimization.md`.

--- a/docs/dependency-architecture-map.html
+++ b/docs/dependency-architecture-map.html
@@ -271,9 +271,9 @@ code { color: #e2e8f0; }
 
         <rect class="node-bg" x="620" y="395" width="240" height="70"/>
         <rect class="node cloud" x="620" y="395" width="240" height="70"/>
-        <text class="title" x="640" y="420">bootstrap::provider_registry</text>
-        <text class="sub" x="640" y="438">ProviderRegistry + ProviderId</text>
-        <text class="sub" x="640" y="453">builds services and adapters</text>
+        <text class="title" x="640" y="420">bootstrap::catalog/registry</text>
+        <text class="sub" x="640" y="438">ProviderCatalog + Registry</text>
+        <text class="sub" x="640" y="453">wires providers and services</text>
 
         <rect class="node-bg" x="310" y="560" width="240" height="60"/>
         <rect class="node backend" x="310" y="560" width="240" height="60"/>
@@ -348,8 +348,8 @@ code { color: #e2e8f0; }
     <div class="card">
       <div class="card-header"><div class="card-dot amber"></div><h3>Composition</h3></div>
       <ul>
-        <li>* `ProviderRegistry` is the concrete composition root.</li>
-        <li>* It builds app services from Brave/Exa and reqwest transport.</li>
+        <li>* `provider_catalog` owns real provider identity and builders.</li>
+        <li>* `ProviderRegistry` builds configured app services from catalog entries.</li>
         <li>* The CLI asks for services; it does not construct providers.</li>
       </ul>
     </div>

--- a/docs/dependency-architecture-map.md
+++ b/docs/dependency-architecture-map.md
@@ -18,7 +18,7 @@ ontology_relations:
 
 # Current Dependency Architecture Map
 
-This is the current/actual Rust import shape after the runtime organization refactor: `src/main.rs` delegates to the CLI runner, the CLI surface performs user-facing branching and rendering, bootstrap owns concrete construction, app services orchestrate domain provider traits, and domain remains the bottom layer.
+This is the current/actual Rust import shape after the runtime organization refactor: `src/main.rs` delegates to the CLI runner, the CLI surface performs user-facing branching and rendering, bootstrap owns the provider catalog plus registry composition, app services orchestrate domain provider traits, and domain remains the bottom layer.
 
 Read every dependency as:
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -18,6 +18,7 @@ A provider-agnostic Rust CLI that queries Brave Search, Exa, or every environmen
 
 - Parses CLI arguments
 - Builds a provider-agnostic `SearchQuery`
+- Resolves real provider tokens through the bootstrap provider catalog
 - Delegates to a single `SearchProvider` for `--provider brave` or `--provider exa`
 - Fans out sequentially to all environment-enabled providers for `--provider all`
 - Renders single-provider or per-provider fan-out results as human-readable text
@@ -27,6 +28,8 @@ A provider-agnostic Rust CLI that queries Brave Search, Exa, or every environmen
 - `src/domain/` — pure types and traits; no HTTP, no CLI
 - `src/transport/` — `HttpClient` trait + `reqwest` adapter
 - `src/providers/brave/` — Brave-specific DTOs, mapper, and client
+- `src/providers/exa/` — Exa-specific DTOs, mapper, and client
+- `src/bootstrap/` — provider catalog, provider registry, and service construction
 - `src/app/` — `SearchService` and `FanoutSearchService` orchestrators
 - `src/cli/` — argument parsing and output rendering
 - `tests/architecture_test.rs` — boundary tests enforcing layer isolation

--- a/docs/project/ARCHITECTURE.md
+++ b/docs/project/ARCHITECTURE.md
@@ -30,7 +30,7 @@ ontology_relations:
 |---|---|---|
 | Entrypoint | `src/main.rs` | Start async runtime and delegate to `cli::runner::run_from_env`. |
 | CLI | `src/cli/` | Parse args, build requests, run CLI workflow, render text output. |
-| Bootstrap | `src/bootstrap/` | Register providers and build services. |
+| Bootstrap | `src/bootstrap/` | Own the provider catalog, register configured providers, and build services. |
 | Application | `src/app/` | Orchestrate single-provider and fan-out search behavior. |
 | Domain | `src/domain/` | Define provider-agnostic query, result, type, error, and provider contracts. |
 | Providers | `src/providers/brave/`, `src/providers/exa/` | Map Brave/Exa APIs into domain contracts. |
@@ -88,7 +88,7 @@ The app layer depends on domain contracts, not concrete provider or transport im
 | Shared result/query shape | `src/domain/` | Preserve provider-agnostic naming. |
 | CLI flag or command behavior | `src/cli/args.rs`, `src/cli/request.rs`, `src/cli/runner.rs` | Keep parsing, request construction, and execution separated. |
 | Output formatting | `src/cli/output.rs` | Keep presentation out of domain/app layers. |
-| Provider registration | `src/bootstrap/provider_registry.rs` | Update integration tests when adding providers. |
+| Provider registration | `src/bootstrap/provider_catalog.rs` | Add real provider identity, CLI token, display name, env var, stable order, and production builder here. Update registry and CLI integration tests when adding providers. |
 | Validation gate | `justfile`, `HARNESS.md`, `.github/workflows/validate-agents.yml` | Keep local and CI docs aligned. |
 
 ## Where Not To Make Changes

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,6 +47,8 @@ cargo run -- "rust async trait" --provider all
 
 `--provider all` includes only providers enabled by the current environment variables. If neither `BRAVE_API_KEY` nor `EXA_API_KEY` is available, the command exits non-zero and prints `no configured providers; set BRAVE_API_KEY and/or EXA_API_KEY`.
 
+The real provider tokens and their environment variables are declared in `src/bootstrap/provider_catalog.rs`. `all` is a CLI-only mode, not a real provider.
+
 ## Search news
 
 ```bash

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1,1 +1,2 @@
+pub mod provider_catalog;
 pub mod provider_registry;

--- a/src/bootstrap/provider_catalog.rs
+++ b/src/bootstrap/provider_catalog.rs
@@ -1,0 +1,146 @@
+use std::fmt;
+
+use crate::domain::SearchProvider;
+use crate::providers::{
+    brave::{client::BraveProvider, config::BraveConfig},
+    exa::{client::ExaProvider, config::ExaConfig},
+};
+use crate::transport::http::ReqwestHttpClient;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProviderId {
+    Brave,
+    Exa,
+}
+
+impl ProviderId {
+    pub fn cli_token(self) -> &'static str {
+        provider_entry(self).cli_token()
+    }
+
+    pub fn display_name(self) -> &'static str {
+        provider_entry(self).display_name()
+    }
+
+    pub fn env_var_name(self) -> &'static str {
+        provider_entry(self).env_var_name()
+    }
+}
+
+impl fmt::Display for ProviderId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.cli_token())
+    }
+}
+
+pub type ProviderBuilder = Box<dyn Fn() -> Box<dyn SearchProvider> + Send + Sync>;
+
+#[derive(Clone, Copy)]
+pub struct ProviderCatalogEntry {
+    id: ProviderId,
+    cli_token: &'static str,
+    display_name: &'static str,
+    env_var_name: &'static str,
+    production_builder: fn() -> Result<ProviderBuilder, std::env::VarError>,
+}
+
+impl ProviderCatalogEntry {
+    pub fn id(self) -> ProviderId {
+        self.id
+    }
+
+    pub fn cli_token(self) -> &'static str {
+        self.cli_token
+    }
+
+    pub fn display_name(self) -> &'static str {
+        self.display_name
+    }
+
+    pub fn env_var_name(self) -> &'static str {
+        self.env_var_name
+    }
+
+    pub fn production_builder(self) -> Result<ProviderBuilder, std::env::VarError> {
+        (self.production_builder)()
+    }
+}
+
+pub static PROVIDER_CATALOG: &[ProviderCatalogEntry] = &[
+    ProviderCatalogEntry {
+        id: ProviderId::Brave,
+        cli_token: "brave",
+        display_name: "Brave Search",
+        env_var_name: "BRAVE_API_KEY",
+        production_builder: build_brave_from_env,
+    },
+    ProviderCatalogEntry {
+        id: ProviderId::Exa,
+        cli_token: "exa",
+        display_name: "Exa",
+        env_var_name: "EXA_API_KEY",
+        production_builder: build_exa_from_env,
+    },
+];
+
+pub fn provider_catalog() -> &'static [ProviderCatalogEntry] {
+    PROVIDER_CATALOG
+}
+
+pub fn default_provider_id() -> ProviderId {
+    provider_catalog()[0].id()
+}
+
+pub fn find_provider_by_cli_token(token: &str) -> Option<ProviderId> {
+    provider_catalog()
+        .iter()
+        .find(|entry| entry.cli_token() == token)
+        .map(|entry| entry.id())
+}
+
+pub fn provider_cli_tokens() -> impl Iterator<Item = &'static str> {
+    provider_catalog().iter().map(|entry| entry.cli_token())
+}
+
+pub fn provider_display_names() -> impl Iterator<Item = &'static str> {
+    provider_catalog().iter().map(|entry| entry.display_name())
+}
+
+pub fn provider_env_var_hint() -> String {
+    let env_vars = provider_catalog()
+        .iter()
+        .map(|entry| entry.env_var_name())
+        .collect::<Vec<_>>();
+
+    match env_vars.as_slice() {
+        [] => "a provider API key".to_string(),
+        [only] => (*only).to_string(),
+        [first, second] => format!("{first} and/or {second}"),
+        [head @ .., last] => format!("{}, and/or {last}", head.join(", ")),
+    }
+}
+
+fn provider_entry(id: ProviderId) -> &'static ProviderCatalogEntry {
+    provider_catalog()
+        .iter()
+        .find(|entry| entry.id() == id)
+        .expect("ProviderId must have a provider catalog entry")
+}
+
+fn build_brave_from_env() -> Result<ProviderBuilder, std::env::VarError> {
+    let config = BraveConfig::from_env()?;
+    let builder: ProviderBuilder = Box::new(move || {
+        Box::new(BraveProvider::new(ReqwestHttpClient::new(), config.clone()))
+            as Box<dyn SearchProvider>
+    });
+    Ok(builder)
+}
+
+fn build_exa_from_env() -> Result<ProviderBuilder, std::env::VarError> {
+    let config = ExaConfig::from_env()?;
+    let builder: ProviderBuilder = Box::new(move || {
+        Box::new(ExaProvider::new(ReqwestHttpClient::new(), config.clone()))
+            as Box<dyn SearchProvider>
+    });
+    Ok(builder)
+}

--- a/src/bootstrap/provider_registry.rs
+++ b/src/bootstrap/provider_registry.rs
@@ -2,44 +2,42 @@ use std::collections::HashMap;
 use std::fmt;
 
 use crate::app::{fanout_search_service::FanoutSearchService, search_service::SearchService};
-use crate::domain::SearchProvider;
-use crate::providers::{
-    brave::{client::BraveProvider, config::BraveConfig},
-    exa::{client::ExaProvider, config::ExaConfig},
-};
-use crate::transport::http::ReqwestHttpClient;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum ProviderId {
-    Brave,
-    Exa,
-}
-
-impl fmt::Display for ProviderId {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ProviderId::Brave => formatter.write_str("brave"),
-            ProviderId::Exa => formatter.write_str("exa"),
-        }
-    }
-}
-
-pub type ProviderBuilder = Box<dyn Fn() -> Box<dyn SearchProvider> + Send + Sync>;
+use crate::bootstrap::provider_catalog;
+pub use crate::bootstrap::provider_catalog::{ProviderBuilder, ProviderId};
 
 pub struct ProviderRegistry {
     builders: HashMap<ProviderId, ProviderBuilder>,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum BuildSearchServiceError {
-    #[error("provider `{provider}` is unavailable; configured providers: {available:?}")]
     ProviderUnavailable {
         provider: ProviderId,
         available: Vec<ProviderId>,
     },
-    #[error("no configured providers; set BRAVE_API_KEY and/or EXA_API_KEY")]
     NoProvidersAvailable,
 }
+
+impl fmt::Display for BuildSearchServiceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BuildSearchServiceError::ProviderUnavailable {
+                provider,
+                available,
+            } => write!(
+                formatter,
+                "provider `{provider}` is unavailable; configured providers: {available:?}"
+            ),
+            BuildSearchServiceError::NoProvidersAvailable => write!(
+                formatter,
+                "no configured providers; set {}",
+                provider_catalog::provider_env_var_hint()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BuildSearchServiceError {}
 
 impl ProviderRegistry {
     pub fn empty() -> Self {
@@ -51,28 +49,10 @@ impl ProviderRegistry {
     pub fn production_from_env() -> Self {
         let mut registry = Self::empty();
 
-        match BraveConfig::from_env() {
-            Ok(config) => {
-                registry.register(
-                    ProviderId::Brave,
-                    Box::new(move || {
-                        Box::new(BraveProvider::new(ReqwestHttpClient::new(), config.clone()))
-                    }),
-                );
+        for entry in provider_catalog::provider_catalog() {
+            if let Ok(builder) = entry.production_builder() {
+                registry.register(entry.id(), builder);
             }
-            Err(std::env::VarError::NotPresent | std::env::VarError::NotUnicode(_)) => {}
-        }
-
-        match ExaConfig::from_env() {
-            Ok(config) => {
-                registry.register(
-                    ProviderId::Exa,
-                    Box::new(move || {
-                        Box::new(ExaProvider::new(ReqwestHttpClient::new(), config.clone()))
-                    }),
-                );
-            }
-            Err(std::env::VarError::NotPresent | std::env::VarError::NotUnicode(_)) => {}
         }
 
         registry
@@ -83,8 +63,9 @@ impl ProviderRegistry {
     }
 
     pub fn available_providers(&self) -> Vec<ProviderId> {
-        [ProviderId::Brave, ProviderId::Exa]
-            .into_iter()
+        provider_catalog::provider_catalog()
+            .iter()
+            .map(|entry| entry.id())
             .filter(|id| self.builders.contains_key(id))
             .collect()
     }
@@ -125,7 +106,7 @@ impl ProviderRegistry {
 mod tests {
     use super::*;
     use crate::domain::{
-        ProviderCapabilities, SearchError, SearchQuery, SearchResponse, SearchType,
+        ProviderCapabilities, SearchError, SearchProvider, SearchQuery, SearchResponse, SearchType,
     };
     use async_trait::async_trait;
     use std::ffi::OsString;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,6 +1,12 @@
+use std::fmt;
+
+use clap::builder::{PossibleValuesParser, TypedValueParser};
 use clap::{Parser, ValueEnum};
 
+use crate::bootstrap::provider_catalog::{self, ProviderId};
 use crate::domain::{SafeSearch, SearchType};
+
+const ALL_PROVIDER_TOKEN: &str = "all";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum CliSearchType {
@@ -38,11 +44,46 @@ impl From<CliSafeSearch> for SafeSearch {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CliProvider {
-    Brave,
-    Exa,
+    Single(ProviderId),
     All,
+}
+
+impl Default for CliProvider {
+    fn default() -> Self {
+        Self::Single(provider_catalog::default_provider_id())
+    }
+}
+
+impl fmt::Display for CliProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CliProvider::Single(provider_id) => provider_id.fmt(formatter),
+            CliProvider::All => formatter.write_str(ALL_PROVIDER_TOKEN),
+        }
+    }
+}
+
+fn cli_provider_value_parser() -> impl TypedValueParser<Value = CliProvider> {
+    PossibleValuesParser::new(valid_provider_tokens()).map(|value| parse_cli_provider(&value))
+}
+
+fn valid_provider_tokens() -> Vec<&'static str> {
+    let mut tokens = provider_catalog::provider_cli_tokens().collect::<Vec<_>>();
+    tokens.push(ALL_PROVIDER_TOKEN);
+    tokens
+}
+
+fn parse_cli_provider(value: &str) -> CliProvider {
+    if value == ALL_PROVIDER_TOKEN {
+        return CliProvider::All;
+    }
+
+    CliProvider::Single(
+        provider_catalog::find_provider_by_cli_token(value)
+            .expect("possible provider token must resolve through provider_catalog"),
+    )
 }
 
 #[derive(Parser, Debug)]
@@ -58,7 +99,7 @@ pub struct CliArgs {
     #[arg(short, long, value_enum, default_value = "web")]
     pub search_type: CliSearchType,
 
-    #[arg(short = 'p', long, value_enum, default_value = "brave")]
+    #[arg(short = 'p', long, value_parser = cli_provider_value_parser(), default_value_t = CliProvider::default())]
     pub provider: CliProvider,
 
     #[arg(short, long)]
@@ -80,16 +121,20 @@ pub struct CliArgs {
 #[cfg(test)]
 mod tests {
     use super::{CliArgs, CliProvider, CliSearchType};
+    use crate::bootstrap::provider_catalog::ProviderId;
     use clap::Parser;
 
     #[test]
     fn test_cli_provider_parses_exa_and_defaults_to_brave() {
         let exa_args = CliArgs::parse_from(["sophon-cli", "--provider", "exa", "rust"]);
-        assert_eq!(exa_args.provider, CliProvider::Exa);
+        assert_eq!(exa_args.provider, CliProvider::Single(ProviderId::Exa));
         assert_eq!(exa_args.search_type, CliSearchType::Web);
 
         let default_args = CliArgs::parse_from(["sophon-cli", "rust"]);
-        assert_eq!(default_args.provider, CliProvider::Brave);
+        assert_eq!(
+            default_args.provider,
+            CliProvider::Single(ProviderId::Brave)
+        );
     }
 
     #[test]
@@ -100,6 +145,21 @@ mod tests {
 
         let default_args =
             CliArgs::try_parse_from(["sophon-cli", "rust"]).expect("default provider parses");
-        assert_eq!(default_args.provider, CliProvider::Brave);
+        assert_eq!(
+            default_args.provider,
+            CliProvider::Single(ProviderId::Brave)
+        );
+    }
+
+    #[test]
+    fn test_cli_provider_rejects_unknown_provider_with_catalog_tokens() {
+        let error = CliArgs::try_parse_from(["sophon-cli", "--provider", "unknown", "rust"])
+            .expect_err("unknown provider should fail")
+            .to_string();
+
+        assert!(error.contains("invalid value 'unknown'"));
+        assert!(error.contains("brave"));
+        assert!(error.contains("exa"));
+        assert!(error.contains("all"));
     }
 }

--- a/src/cli/runner.rs
+++ b/src/cli/runner.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 
-use crate::bootstrap::provider_registry::{ProviderId, ProviderRegistry};
+use crate::bootstrap::provider_catalog::{self, ProviderId};
+use crate::bootstrap::provider_registry::ProviderRegistry;
 use crate::cli::args::{CliArgs, CliProvider};
 use crate::cli::output::{render_fanout_text, render_text};
 use crate::cli::request::build_search_query;
@@ -29,8 +30,9 @@ pub async fn run(args: CliArgs) -> i32 {
     let registry = ProviderRegistry::production_from_env();
 
     match args.provider {
-        CliProvider::Brave => run_single_provider(&registry, ProviderId::Brave, query).await,
-        CliProvider::Exa => run_single_provider(&registry, ProviderId::Exa, query).await,
+        CliProvider::Single(provider_id) => {
+            run_single_provider(&registry, provider_id, query).await
+        }
         CliProvider::All => run_all_enabled(&registry, query).await,
     }
 }
@@ -43,7 +45,12 @@ fn print_about() {
     println!("across vast distances. This tiny CLI delegates its heavy lifting to");
     println!("distant search APIs the same way.");
     println!();
-    println!("Currently supports Brave Search (web, news, images, video) and Exa.");
+    println!(
+        "Currently supports {}.",
+        provider_catalog::provider_display_names()
+            .collect::<Vec<_>>()
+            .join(" and ")
+    );
 }
 
 async fn run_single_provider(

--- a/tests/architecture_test.rs
+++ b/tests/architecture_test.rs
@@ -60,6 +60,79 @@ fn test_render_text_only_called_from_cli() {
 }
 
 #[test]
+fn test_provider_catalog_is_provider_wiring_source_of_truth() {
+    assert!(
+        Path::new("src/bootstrap/provider_catalog.rs").exists(),
+        "provider identity and production wiring must live in src/bootstrap/provider_catalog.rs"
+    );
+
+    let bootstrap_mod = read_repo_file("src/bootstrap/mod.rs");
+    assert!(
+        bootstrap_mod.contains("pub mod provider_catalog;"),
+        "bootstrap must expose the provider catalog module"
+    );
+
+    let catalog = read_repo_file("src/bootstrap/provider_catalog.rs");
+    for required_pattern in [
+        "pub enum ProviderId",
+        "ProviderCatalogEntry",
+        "PROVIDER_CATALOG",
+        "BraveProvider::new",
+        "ExaProvider::new",
+        "BRAVE_API_KEY",
+        "EXA_API_KEY",
+    ] {
+        assert!(
+            catalog.contains(required_pattern),
+            "provider catalog must contain provider wiring pattern {required_pattern:?}"
+        );
+    }
+
+    let registry = read_repo_file("src/bootstrap/provider_registry.rs");
+    let registry_impl = implementation_region(&registry);
+    for forbidden_pattern in [
+        "pub enum ProviderId",
+        "BraveConfig::from_env",
+        "ExaConfig::from_env",
+        "BraveProvider::new",
+        "ExaProvider::new",
+        "[ProviderId::Brave, ProviderId::Exa]",
+        "BRAVE_API_KEY and/or EXA_API_KEY",
+    ] {
+        assert!(
+            !registry_impl.contains(forbidden_pattern),
+            "provider registry wiring must come from provider_catalog, but found {forbidden_pattern:?}"
+        );
+    }
+
+    let cli_args = read_repo_file("src/cli/args.rs");
+    let cli_args_impl = implementation_region(&cli_args);
+    for forbidden_pattern in [
+        "CliProvider {\n    Brave",
+        "ValueEnum)]\npub enum CliProvider",
+    ] {
+        assert!(
+            !cli_args_impl.contains(forbidden_pattern),
+            "CLI provider parsing must resolve real providers from provider_catalog; found {forbidden_pattern:?}"
+        );
+    }
+
+    let runner = read_repo_file("src/cli/runner.rs");
+    let runner_impl = implementation_region(&runner);
+    for forbidden_pattern in [
+        "CliProvider::Brave",
+        "CliProvider::Exa",
+        "ProviderId::Brave",
+        "ProviderId::Exa",
+    ] {
+        assert!(
+            !runner_impl.contains(forbidden_pattern),
+            "CLI runner must use catalog-backed provider IDs; found {forbidden_pattern:?}"
+        );
+    }
+}
+
+#[test]
 fn test_t001_cli_request_module_import_contract() {
     let cli_mod = read_repo_file("src/cli/mod.rs");
     assert!(
@@ -230,6 +303,10 @@ fn read_repo_file(path: &str) -> String {
     fs::read_to_string(path).unwrap_or_else(|error| {
         panic!("Expected {path} to exist for import-organization contract test: {error}")
     })
+}
+
+fn implementation_region(content: &str) -> &str {
+    content.split("#[cfg(test)]").next().unwrap_or(content)
 }
 
 fn visit_rust_files(dir: &str, callback: &dyn Fn(&Path, &str)) {

--- a/tests/integration/cli_test.rs
+++ b/tests/integration/cli_test.rs
@@ -2,6 +2,7 @@
 mod cli;
 
 use clap::Parser;
+use sophon_cli::bootstrap::provider_catalog::ProviderId;
 use sophon_cli::cli::args::{CliArgs, CliProvider, CliSafeSearch, CliSearchType};
 
 #[test]
@@ -88,6 +89,29 @@ fn cli_with_explicit_arguments_parses_correctly() {
     assert_eq!(args.safe_search, Some(CliSafeSearch::Strict));
     assert_eq!(args.country.as_deref(), Some("US"));
     assert_eq!(args.language.as_deref(), Some("en"));
+}
+
+#[test]
+fn cli_unknown_provider_fails_at_parse_time_with_catalog_tokens_and_all() {
+    let error = CliArgs::try_parse_from(["sophon-cli", "rust", "--provider", "unknown"])
+        .expect_err("unknown provider should fail")
+        .to_string();
+
+    assert!(error.contains("invalid value 'unknown'"));
+    assert!(error.contains("brave"));
+    assert!(error.contains("exa"));
+    assert!(error.contains("all"));
+}
+
+#[test]
+fn cli_real_provider_tokens_parse_to_catalog_provider_ids() {
+    let brave_args = CliArgs::try_parse_from(["sophon-cli", "rust", "--provider", "brave"])
+        .expect("brave provider parses");
+    assert_eq!(brave_args.provider, CliProvider::Single(ProviderId::Brave));
+
+    let exa_args = CliArgs::try_parse_from(["sophon-cli", "rust", "--provider", "exa"])
+        .expect("exa provider parses");
+    assert_eq!(exa_args.provider, CliProvider::Single(ProviderId::Exa));
 }
 
 fn assert_explicit_provider_unavailable(output: std::process::Output, provider: &str) {

--- a/tests/integration/provider_registry_test.rs
+++ b/tests/integration/provider_registry_test.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
-use sophon_cli::bootstrap::provider_registry::{
-    BuildSearchServiceError, ProviderBuilder, ProviderId, ProviderRegistry,
+use sophon_cli::bootstrap::{
+    provider_catalog::{ProviderBuilder, ProviderId, provider_catalog, provider_env_var_hint},
+    provider_registry::{BuildSearchServiceError, ProviderRegistry},
 };
 use sophon_cli::domain::{
     ProviderCapabilities, SearchError, SearchProvider, SearchQuery, SearchResponse, SearchType,
@@ -100,6 +101,22 @@ fn search_query(text: &str) -> SearchQuery {
         language: None,
         time_range: None,
     }
+}
+
+#[test]
+fn provider_catalog_declares_real_providers_in_stable_order() {
+    let catalog_entries = provider_catalog();
+
+    assert_eq!(catalog_entries.len(), 2);
+    assert_eq!(catalog_entries[0].id(), ProviderId::Brave);
+    assert_eq!(catalog_entries[0].cli_token(), "brave");
+    assert_eq!(catalog_entries[0].display_name(), "Brave Search");
+    assert_eq!(catalog_entries[0].env_var_name(), "BRAVE_API_KEY");
+    assert_eq!(catalog_entries[1].id(), ProviderId::Exa);
+    assert_eq!(catalog_entries[1].cli_token(), "exa");
+    assert_eq!(catalog_entries[1].display_name(), "Exa");
+    assert_eq!(catalog_entries[1].env_var_name(), "EXA_API_KEY");
+    assert_eq!(provider_env_var_hint(), "BRAVE_API_KEY and/or EXA_API_KEY");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a bootstrap-owned provider catalog as the source of truth for real provider identity, CLI tokens, display names, environment variable names, stable ordering, and production construction.

## What changed

- Added `src/bootstrap/provider_catalog.rs` with ordered Brave and Exa catalog entries and production builders.
- Refactored `ProviderRegistry` to build configured providers and stable order from the catalog.
- Refactored CLI provider parsing to use catalog-backed `ProviderId` values while keeping `all` as a CLI-only aggregate mode.
- Added architecture and integration tests covering catalog ownership, metadata, CLI parsing, unknown-provider errors, and provider order.
- Updated README, mdBook architecture/quickstart docs, harness docs, and provider-catalog evidence/memory artifacts.

## Validation

- Captured failing-first catalog architecture regression before implementation.
- `cargo test --test architecture_test`
- `cargo test --test provider_registry_integration`
- `cargo test --test cli_integration`
- `cargo test cli::args`
- `python3 scripts/check_markdown_frontmatter.py`
- `mdbook build`
- `cargo run -- --help`
- `just check` passed locally and in the pre-push hook.

## Notes

No live Brave or Exa API calls were run; live provider calls remain outside automated evidence. The existing generated `scripts/__pycache__/` and the pre-existing staged architecture-exploration artifacts were left out of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized provider identity, CLI token resolution, and environment variable configuration into a unified provider catalog system for improved consistency and maintainability.

* **Documentation**
  * Updated project documentation to clarify provider selection semantics, environment variable wiring, and the CLI-only nature of the `--provider all` mode.
  * Improved guidance on supported providers and their configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->