### PR TITLE
[codex] append result URL list to CLI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changelog coverage test that verifies merged PRs are referenced in `CHANGELOG.md`. (#17)
 - Markdown artifact control-plane docs, a compact `AGENTS.md` map, and `.DS_Store` cleanup. (#18)
 - Bootstrap provider catalog as the single source of truth for provider identity, CLI tokens, environment variable metadata, stable ordering, and production provider construction. (#19)
+- CLI result output now appends a final `URLs:` block for easier link copying while preserving existing inline result URLs. (#20)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ sophon-cli "vector database benchmarks" --provider exa --limit 5
 sophon-cli "rust async trait" --provider all
 ```
 
+### Output format
+
+Each result is printed inline with its title and `URL:`. A trailing `URLs:` block collects every non-empty result link so they're easy to copy in one pass:
+
+```text
+Provider: brave
+Query: rust programming
+Results: 2
+
+1. [Rust Programming Language]
+   URL: https://www.rust-lang.org
+   A language empowering everyone to build reliable and efficient software.
+2. [Rust (programming language) - Wikipedia]
+   URL: https://en.wikipedia.org/wiki/Rust_(programming_language)
+
+URLs:
+- https://www.rust-lang.org
+- https://en.wikipedia.org/wiki/Rust_(programming_language)
+```
+
+Result ordering and inline `URL:` lines are unchanged; whitespace-only URLs are skipped in the `URLs:` list.
+
 ## Supported providers
 
 Real provider tokens:

--- a/docs/artifacts/active/CHARTER-20260531-result-url-list.md
+++ b/docs/artifacts/active/CHARTER-20260531-result-url-list.md
@@ -1,0 +1,127 @@
+---
+title: "Session charter: result URL list"
+when_to_read:
+  - "Before adding an end-of-output URL list to CLI rendered search results."
+  - "When changing result URL rendering behavior in src/cli/output.rs."
+summary: "Defines the feature scope, constraints, regression checks, and minimal implementation plan for appending a result URL list to CLI output."
+ontology_relations:
+  - relation: "governs"
+    target: "sophon-cli-result-url-list"
+    note: "Sets the execution scope for adding an end-of-results URL list."
+  - relation: "depends_on"
+    target: "docs/artifacts/explorations/EXP-20260531-result-url-surface.md"
+    note: "Uses research showing result URLs already flow through domain results, provider mappers, and CLI rendering."
+---
+
+# Session Charter
+
+| Field | Value |
+|---|---|
+| Artifact Type | Session Charter |
+| Status | Completed |
+| Date | 2026-05-31 |
+| Owner | Codex |
+| Related Artifacts | `docs/artifacts/explorations/EXP-20260531-result-url-surface.md`, `docs/artifacts/memory/MEM-20260531-result-url-research.md`, `docs/artifacts/active/EXEC-20260531-result-url-list.md`, `docs/artifacts/evidence/EVID-20260531-result-url-list.md`, `docs/artifacts/memory/MEM-20260531-result-url-implementation.md` |
+| Related Files | `src/cli/output.rs`, `src/domain/result.rs`, `docs/project/ARCHITECTURE.md`, `docs/project/TESTING.md`, `HARNESS.md` |
+
+## Mission
+
+Append a compact list of result URLs at the end of rendered CLI search results with the least amount of code.
+
+## Work Type
+
+Feature
+
+## Context
+
+- `docs/artifacts/explorations/EXP-20260531-result-url-surface.md` found that result URLs already exist in every normalized result variant.
+- Brave and Exa mappers already populate the domain URL fields.
+- `src/cli/output.rs` already prints an inline `URL:` line for web, news, image, and video results.
+- The requested change is a presentation-layer addition, not a data-flow change.
+- Fan-out output already delegates each successful provider response to `render_text`, so a single-provider renderer change naturally appears inside each provider section.
+
+## Scope
+
+### In Scope
+
+- Update `src/cli/output.rs` so `render_text` appends a final URL summary block after all rendered result details.
+- Include web, news, image, and video result URLs in the same order as `response.results`.
+- Keep the existing per-result `URL:` lines unchanged.
+- Skip empty or whitespace-only URL strings in the final list.
+- Preserve duplicate URLs if duplicate results appear.
+- Let `render_fanout_text` inherit provider-local URL lists through its existing `render_text(provider_response)` call.
+- Add or update one focused unit test in `src/cli/output.rs` proving the URL list appears at the end.
+
+### Out of Scope
+
+- Changing domain result structs.
+- Changing provider DTOs, mappers, HTTP clients, or application services.
+- Adding URL validation, normalization, sorting, or de-duplication.
+- Adding a separate global URL list for `--provider all`.
+- Changing CLI arguments, stdout/stderr routing, provider selection, or query construction.
+- Updating user-facing docs for this small output-format change unless execution reveals an existing stale claim.
+- Running live Brave or Exa API calls.
+
+## Constraints
+
+- Keep the change localized to `src/cli/output.rs` unless a test-only helper must move.
+- Do not add dependencies.
+- Preserve architecture boundaries: output formatting stays in `src/cli/`; domain and providers stay presentation-agnostic.
+- Preserve existing text output above the appended URL list.
+- Use a small helper or match expression rather than adding methods to domain types.
+- New tracked Markdown must pass `python3 scripts/check_markdown_frontmatter.py`.
+
+## Risk Areas
+
+- Output-format tests or downstream consumers may depend on the current trailing text shape.
+- Provider mappers can default missing URLs to empty strings, so the final list must not print blank bullets.
+- Fan-out output will contain one URL list per successful provider section, not one aggregate list after failures.
+
+## Regression Checks
+
+- Existing web, news, image, and video result details still render with title and inline `URL:` lines.
+- Existing snippets, news source lines, fan-out success counts, fan-out failure counts, and failure messages remain unchanged.
+- A response with no non-empty URLs does not append an empty URL summary block.
+- Architecture boundary tests continue to pass because no non-CLI layer imports rendering code.
+
+## Rollback Plan
+
+Revert the `src/cli/output.rs` renderer and unit-test changes. No data model, provider, configuration, or migration rollback is required.
+
+## Plan
+
+1. Add a focused output-rendering test in `src/cli/output.rs` that expects the rendered text to end with a `URLs:` block containing result URLs in result order.
+2. Add the smallest local URL extraction helper or match expression needed to read `url` from `SearchResult::{Web, News, Image, Video}`.
+3. In `render_text`, collect non-empty trimmed URL strings after the existing per-result rendering loop.
+4. If at least one URL exists, append a final block with the exact shape:
+
+   ```text
+   URLs:
+   - https://example.com/one
+   - https://example.com/two
+   ```
+
+5. Confirm `render_fanout_text` needs no new branching because it already calls `render_text` for each provider response.
+6. Run targeted output tests, then the repository gate if practical.
+7. Create evidence and session memory before claiming the implementation complete.
+
+## Evidence Required
+
+- `cargo test render_text_appends_url_list_at_end` passes, or the final test name used during execution is documented.
+- `cargo test` passes after the renderer change.
+- `python3 scripts/check_markdown_frontmatter.py` passes after artifact updates.
+- `just check` passes, or any skipped/failed check is documented in the evidence pack with the reason and output summary.
+- Diff review confirms no domain, provider, transport, app, bootstrap, CLI argument, or runner changes were needed.
+
+## Exit Criteria
+
+- Single-provider CLI text output ends with a compact URL list when results contain non-empty URLs.
+- The URL list preserves result order and includes all result variants.
+- Empty URL strings do not produce blank URL-list entries.
+- Fan-out output includes the same provider-local URL list through the existing renderer delegation.
+- Existing inline result URL lines and surrounding output remain unchanged.
+- Evidence and session memory artifacts exist for the implementation session.
+
+## Clarifications Needed Before Editing
+
+None. Assumption: "at the end" means at the end of each rendered `SearchResponse`; fan-out will therefore show one URL list per successful provider section unless a later requirement asks for a global batch-level URL list.

--- a/docs/artifacts/active/EXEC-20260531-result-url-list.md
+++ b/docs/artifacts/active/EXEC-20260531-result-url-list.md
@@ -1,0 +1,68 @@
+---
+title: "Execution log: result URL list"
+when_to_read:
+  - "When continuing or reviewing the result URL list implementation."
+  - "When checking how CLI output URL summary behavior was implemented."
+summary: "Tracks the scoped implementation of appending provider-local URL summary blocks to rendered CLI search results."
+ontology_relations:
+  - relation: "tracks"
+    target: "docs/artifacts/active/CHARTER-20260531-result-url-list.md"
+    note: "Records execution against the active result URL list charter."
+---
+
+# Execution Log
+
+| Field | Value |
+|---|---|
+| Artifact Type | Execution Log |
+| Status | Completed |
+| Date | 2026-05-31 |
+| Owner | Codex |
+| Related Artifacts | `docs/artifacts/active/CHARTER-20260531-result-url-list.md`, `docs/artifacts/evidence/EVID-20260531-result-url-list.md`, `docs/artifacts/memory/MEM-20260531-result-url-implementation.md` |
+| Related Files | `src/cli/output.rs` |
+
+## Starting Point
+
+- Current branch: `main`.
+- Current short commit when this log was created: `1acaefd`.
+- The worktree already contained uncommitted documentation/artifact changes before implementation started: `docs/SUMMARY.md`, `docs/artifacts/active/CHARTER-20260531-result-url-list.md`, `docs/artifacts/explorations/EXP-20260531-result-url-surface.md`, `docs/artifacts/memory/MEM-20260531-result-url-plan.md`, `docs/artifacts/memory/MEM-20260531-result-url-research.md`, and `docs/artifacts/templates/README.md`.
+- Rollback commit was not created because it would have staged and committed pre-existing user/session work outside this execution scope.
+- The scoped implementation file is `src/cli/output.rs`.
+
+## Timeline
+
+Implementation completed in this session. Evidence is recorded in `docs/artifacts/evidence/EVID-20260531-result-url-list.md`.
+
+### Step 1
+
+- Action: Add a focused renderer test that expects a final URL summary block in result order.
+- Files touched: `src/cli/output.rs`
+- Result: Completed.
+- Evidence: Added `render_text_appends_url_list_at_end`; targeted `cargo test render_text_appends_url_list_at_end` passed.
+
+### Step 2
+
+- Action: Add local URL extraction and append non-empty URLs to `render_text`.
+- Files touched: `src/cli/output.rs`
+- Result: Completed.
+- Evidence: `render_text` now appends a trailing `URLs:` block from `SearchResult::{Web, News, Image, Video}` URL fields, trims URL-list entries, skips whitespace-only URLs, and leaves existing inline `URL:` lines unchanged. `render_fanout_text` needed no new branching because it already calls `render_text` for each provider response.
+
+### Step 3
+
+- Action: Validate with targeted tests, full tests, markdown frontmatter, and canonical gate if practical.
+- Result: Completed.
+- Evidence: `cargo test render_text_appends_url_list_at_end` passed. `just check` passed, including `cargo fmt --check`, clippy with warnings denied, `cargo test`, `python3 scripts/check_markdown_frontmatter.py`, and `mdbook build`.
+
+## Deviations From Charter
+
+- Rollback commit was not created. The worktree already contained uncommitted documentation/artifact changes before implementation started, so creating a rollback commit would have committed work outside this execution scope.
+
+## Bugs Found
+
+- None.
+
+## Notes For Evidence Pack
+
+- `render_fanout_text` needed no changes.
+- Targeted test name: `render_text_appends_url_list_at_end`.
+- Canonical gate outcome: `just check` passed.

--- a/docs/artifacts/active/EXEC-20260531-result-url-list.md
+++ b/docs/artifacts/active/EXEC-20260531-result-url-list.md
@@ -19,7 +19,7 @@ ontology_relations:
 | Date | 2026-05-31 |
 | Owner | Codex |
 | Related Artifacts | `docs/artifacts/active/CHARTER-20260531-result-url-list.md`, `docs/artifacts/evidence/EVID-20260531-result-url-list.md`, `docs/artifacts/memory/MEM-20260531-result-url-implementation.md` |
-| Related Files | `src/cli/output.rs` |
+| Related Files | `src/cli/output.rs`, `CHANGELOG.md` |
 
 ## Starting Point
 
@@ -53,6 +53,13 @@ Implementation completed in this session. Evidence is recorded in `docs/artifact
 - Result: Completed.
 - Evidence: `cargo test render_text_appends_url_list_at_end` passed. `just check` passed, including `cargo fmt --check`, clippy with warnings denied, `cargo test`, `python3 scripts/check_markdown_frontmatter.py`, and `mdbook build`.
 
+### Step 4
+
+- Action: Add the assigned draft PR number to the changelog before merge.
+- Files touched: `CHANGELOG.md`, `docs/artifacts/active/EXEC-20260531-result-url-list.md`, `docs/artifacts/evidence/EVID-20260531-result-url-list.md`, `docs/artifacts/memory/MEM-20260531-result-url-implementation.md`
+- Result: Completed.
+- Evidence: PR `#20` is now referenced in `CHANGELOG.md`; focused changelog and markdown checks passed.
+
 ## Deviations From Charter
 
 - Rollback commit was not created. The worktree already contained uncommitted documentation/artifact changes before implementation started, so creating a rollback commit would have committed work outside this execution scope.
@@ -66,3 +73,4 @@ Implementation completed in this session. Evidence is recorded in `docs/artifact
 - `render_fanout_text` needed no changes.
 - Targeted test name: `render_text_appends_url_list_at_end`.
 - Canonical gate outcome: `just check` passed.
+- Changelog follow-up validation: `cargo test --test changelog_test` and `python3 scripts/check_markdown_frontmatter.py` passed.

--- a/docs/artifacts/evidence/EVID-20260531-result-url-list.md
+++ b/docs/artifacts/evidence/EVID-20260531-result-url-list.md
@@ -22,11 +22,13 @@ ontology_relations:
 | Date | 2026-05-31 |
 | Owner | Codex |
 | Related Artifacts | `docs/artifacts/active/CHARTER-20260531-result-url-list.md`, `docs/artifacts/active/EXEC-20260531-result-url-list.md`, `docs/artifacts/memory/MEM-20260531-result-url-implementation.md` |
-| Related Files | `src/cli/output.rs` |
+| Related Files | `src/cli/output.rs`, `CHANGELOG.md` |
 
 ## Claim Being Proven
 
 Rendered single-provider CLI output now ends with a compact `URLs:` summary block when results contain non-empty URLs. The list preserves `response.results` order, trims whitespace for summary entries, skips whitespace-only URLs, preserves existing inline `URL:` lines, and fan-out output inherits one provider-local URL list per successful provider through the existing `render_text` delegation.
+
+The unreleased changelog also references PR `#20` for this user-visible output change.
 
 ## Files Reviewed
 
@@ -38,6 +40,7 @@ Rendered single-provider CLI output now ends with a compact `URLs:` summary bloc
 ## Files Changed
 
 - `src/cli/output.rs`: appended URL summary rendering to `render_text`, added a local `result_url` helper, and added the focused `render_text_appends_url_list_at_end` unit test.
+- `CHANGELOG.md`: added the unreleased result URL list entry with PR `#20`.
 - `docs/artifacts/active/EXEC-20260531-result-url-list.md`: recorded execution progress and validation.
 - `docs/artifacts/evidence/EVID-20260531-result-url-list.md`: added this evidence pack.
 - `docs/artifacts/memory/MEM-20260531-result-url-implementation.md`: added session memory.
@@ -49,6 +52,7 @@ cargo fmt
 cargo test render_text_appends_url_list_at_end
 cargo test
 just check
+cargo test --test changelog_test
 python3 scripts/check_markdown_frontmatter.py
 git diff -- src/cli/output.rs docs/artifacts/active/EXEC-20260531-result-url-list.md
 ```
@@ -60,6 +64,7 @@ git diff -- src/cli/output.rs docs/artifacts/active/EXEC-20260531-result-url-lis
 | Focused renderer test | `cargo test render_text_appends_url_list_at_end` | Passed | 1 passed; proves final URL block ordering and whitespace-only URL skipping in the summary. |
 | Full Rust suite | `cargo test` | Passed | 30 lib tests, 13 architecture tests, 2 changelog tests, 3 CI direction tests, 8 CLI integration tests, 1 fan-out CLI test, 13 provider registry tests, and 6 search service tests passed. |
 | Canonical gate | `just check` | Passed | Includes `cargo fmt --check`, clippy with warnings denied, `cargo test`, markdown frontmatter, and `mdbook build`. |
+| Changelog coverage | `cargo test --test changelog_test` | Passed | Passes after adding PR `#20` to `CHANGELOG.md`. |
 | Markdown frontmatter | `python3 scripts/check_markdown_frontmatter.py` | Passed | Final artifact check completed without errors. |
 | Diff review | `git diff -- src/cli/output.rs ...` and source review | Passed | Code changes are limited to CLI rendering and unit tests; no domain, provider, transport, app, bootstrap, CLI argument, or runner changes were needed. |
 

--- a/docs/artifacts/evidence/EVID-20260531-result-url-list.md
+++ b/docs/artifacts/evidence/EVID-20260531-result-url-list.md
@@ -1,0 +1,81 @@
+---
+title: "Evidence: result URL list"
+when_to_read:
+  - "When verifying the CLI result URL summary implementation."
+  - "When checking why the result URL list feature was considered complete."
+summary: "Evidence that rendered CLI search results now append a provider-local final URL list while preserving existing inline result details."
+ontology_relations:
+  - relation: "supports"
+    target: "docs/artifacts/active/CHARTER-20260531-result-url-list.md"
+    note: "Provides validation evidence for the result URL list session charter."
+  - relation: "recorded_by"
+    target: "docs/artifacts/active/EXEC-20260531-result-url-list.md"
+    note: "Matches the execution log for this implementation session."
+---
+
+# Evidence Pack
+
+| Field | Value |
+|---|---|
+| Artifact Type | Evidence Pack |
+| Status | Completed |
+| Date | 2026-05-31 |
+| Owner | Codex |
+| Related Artifacts | `docs/artifacts/active/CHARTER-20260531-result-url-list.md`, `docs/artifacts/active/EXEC-20260531-result-url-list.md`, `docs/artifacts/memory/MEM-20260531-result-url-implementation.md` |
+| Related Files | `src/cli/output.rs` |
+
+## Claim Being Proven
+
+Rendered single-provider CLI output now ends with a compact `URLs:` summary block when results contain non-empty URLs. The list preserves `response.results` order, trims whitespace for summary entries, skips whitespace-only URLs, preserves existing inline `URL:` lines, and fan-out output inherits one provider-local URL list per successful provider through the existing `render_text` delegation.
+
+## Files Reviewed
+
+- `docs/artifacts/active/CHARTER-20260531-result-url-list.md`
+- `docs/artifacts/active/EXEC-20260531-result-url-list.md`
+- `src/cli/output.rs`
+- `src/domain/result.rs`
+
+## Files Changed
+
+- `src/cli/output.rs`: appended URL summary rendering to `render_text`, added a local `result_url` helper, and added the focused `render_text_appends_url_list_at_end` unit test.
+- `docs/artifacts/active/EXEC-20260531-result-url-list.md`: recorded execution progress and validation.
+- `docs/artifacts/evidence/EVID-20260531-result-url-list.md`: added this evidence pack.
+- `docs/artifacts/memory/MEM-20260531-result-url-implementation.md`: added session memory.
+
+## Commands Run
+
+```bash
+cargo fmt
+cargo test render_text_appends_url_list_at_end
+cargo test
+just check
+python3 scripts/check_markdown_frontmatter.py
+git diff -- src/cli/output.rs docs/artifacts/active/EXEC-20260531-result-url-list.md
+```
+
+## Test Results
+
+| Check | Command / Method | Result | Notes |
+|---|---|---|---|
+| Focused renderer test | `cargo test render_text_appends_url_list_at_end` | Passed | 1 passed; proves final URL block ordering and whitespace-only URL skipping in the summary. |
+| Full Rust suite | `cargo test` | Passed | 30 lib tests, 13 architecture tests, 2 changelog tests, 3 CI direction tests, 8 CLI integration tests, 1 fan-out CLI test, 13 provider registry tests, and 6 search service tests passed. |
+| Canonical gate | `just check` | Passed | Includes `cargo fmt --check`, clippy with warnings denied, `cargo test`, markdown frontmatter, and `mdbook build`. |
+| Markdown frontmatter | `python3 scripts/check_markdown_frontmatter.py` | Passed | Final artifact check completed without errors. |
+| Diff review | `git diff -- src/cli/output.rs ...` and source review | Passed | Code changes are limited to CLI rendering and unit tests; no domain, provider, transport, app, bootstrap, CLI argument, or runner changes were needed. |
+
+## Manual Verification
+
+1. Reviewed `src/cli/output.rs` and confirmed existing per-result inline `URL:` lines remain unchanged for web, news, image, and video results.
+2. Confirmed `render_text` collects URLs after the normal result rendering loop, trims entries for the summary, skips whitespace-only URLs, and appends the summary only when at least one URL remains.
+3. Confirmed `render_fanout_text` still calls `render_text(provider_response)` for each successful provider, so fan-out inherits provider-local URL lists without new fan-out branching.
+4. Reviewed architecture scope: no domain, provider, transport, app, bootstrap, CLI argument, or runner code changed.
+
+## Known Gaps
+
+- No live Brave or Exa API calls were run; the charter explicitly excluded live provider calls.
+- Existing uncommitted documentation/artifact changes predated implementation and were left in place.
+- A rollback commit was not created because it would have committed pre-existing work outside this scope.
+
+## Final Evidence Judgment
+
+Proven. The renderer now appends the requested URL list, the focused regression covers the output ending and URL filtering behavior, fan-out inherits the behavior through the existing renderer delegation, and the canonical `just check` gate passed.

--- a/docs/artifacts/explorations/EXP-20260531-result-url-surface.md
+++ b/docs/artifacts/explorations/EXP-20260531-result-url-surface.md
@@ -1,0 +1,250 @@
+---
+title: "Research: Result URL surface"
+when_to_read:
+  - "When planning or implementing changes to URLs returned in search results."
+  - "When checking how provider result URLs flow into CLI output."
+summary: "Maps where search-result URLs are represented, mapped, preserved, rendered, and tested in sophon-cli."
+research_type: "feature"
+commitment_status: "decision-support"
+research_goal: "Map the current code paths that carry provider-returned result URLs into normalized results and CLI text output."
+uuid: "487FF3C3-E993-4D17-A9BA-7C6CA331773F"
+created_at: "2026-05-31T11:15:23-05:00"
+tags: [research, feature, urls, results, cli-output]
+ontology_relations:
+  - relation: "explores"
+    target: "sophon-cli-result-url-surface"
+    note: "Captures factual research about URL fields in normalized search results and output rendering."
+  - relation: "relates_to"
+    target: "docs/project/ARCHITECTURE.md"
+    note: "Uses the documented provider-to-domain-to-CLI data flow as the research frame."
+  - relation: "relates_to"
+    target: "docs/artifacts/INDEX.md"
+    note: "Stores the research in the tracked markdown artifact control plane."
+---
+
+# Exploration Memory
+
+| Field | Value |
+|---|---|
+| Artifact Type | Exploration Memory |
+| Status | Active |
+| Date | 2026-05-31 |
+| Owner | Codex |
+| Research Type | `feature` |
+| Commitment Status | `decision-support` |
+| Related Artifacts | `docs/project/ARCHITECTURE.md`, `docs/project/PROJECT_CONTEXT.md`, `docs/artifacts/INDEX.md` |
+| Related Files | `src/domain/result.rs`, `src/providers/brave/dto.rs`, `src/providers/brave/mapper.rs`, `src/providers/exa/dto.rs`, `src/providers/exa/mapper.rs`, `src/app/search_service.rs`, `src/app/fanout_search_service.rs`, `src/cli/output.rs`, `src/cli/runner.rs` |
+
+## Research Intent
+
+- Research type: `feature`
+- Commitment status: `decision-support`
+- Goal: map the current code paths that carry provider-returned result URLs into normalized domain results and CLI output.
+- Out of scope: source-code changes, CLI UX changes, result-schema changes, provider API behavior changes, and deciding an implementation plan.
+
+## Question
+
+Where does sophon-cli currently represent, map, preserve, and print URLs returned from provider search results?
+
+## Structure
+
+- `src/domain/result.rs` defines normalized response and result structs for provider-agnostic results.
+- `src/providers/brave/dto.rs` defines Brave response DTOs with optional URL fields.
+- `src/providers/brave/mapper.rs` maps Brave DTO URL fields into normalized domain result URL fields.
+- `src/providers/exa/dto.rs` defines Exa response DTOs with optional URL fields.
+- `src/providers/exa/mapper.rs` maps Exa DTO URL fields into normalized domain result URL fields.
+- `src/app/search_service.rs` delegates a single-provider search and returns the provider response.
+- `src/app/fanout_search_service.rs` aggregates provider `SearchResponse` values into `SearchBatchResponse`.
+- `src/cli/output.rs` renders single-provider and fan-out result text.
+- `src/cli/runner.rs` prints rendered single-provider and fan-out output to stdout.
+
+## Key Files
+
+- `src/domain/result.rs:7` defines `SearchResponse`.
+- `src/domain/result.rs:10` stores normalized results as `Vec<SearchResult>`.
+- `src/domain/result.rs:29` defines `SearchResult::{Web, News, Image, Video}`.
+- `src/domain/result.rs:37` defines `WebResult`.
+- `src/domain/result.rs:39` defines `WebResult.url: String`.
+- `src/domain/result.rs:45` defines `NewsResult`.
+- `src/domain/result.rs:47` defines `NewsResult.url: String`.
+- `src/domain/result.rs:54` defines `ImageResult`.
+- `src/domain/result.rs:56` defines `ImageResult.url: String`.
+- `src/domain/result.rs:62` defines `VideoResult`.
+- `src/domain/result.rs:64` defines `VideoResult.url: String`.
+- `src/domain/mod.rs:10` re-exports result structs from the domain module surface.
+- `src/domain/provider.rs:18` defines the `SearchProvider` trait.
+- `src/domain/provider.rs:23` returns `Result<SearchResponse, SearchError>` from `SearchProvider::search`.
+
+## Provider URL Inputs
+
+### Brave
+
+- `src/providers/brave/dto.rs:21` defines `BraveWebResult`.
+- `src/providers/brave/dto.rs:23` defines `BraveWebResult.url: Option<String>`.
+- `src/providers/brave/dto.rs:41` defines `BraveNewsResult`.
+- `src/providers/brave/dto.rs:43` defines `BraveNewsResult.url: Option<String>`.
+- `src/providers/brave/dto.rs:57` defines `BraveImageResult`.
+- `src/providers/brave/dto.rs:59` defines `BraveImageResult.url: Option<String>`.
+- `src/providers/brave/dto.rs:82` defines `BraveVideoResult`.
+- `src/providers/brave/dto.rs:84` defines `BraveVideoResult.url: Option<String>`.
+- `src/providers/brave/client.rs:93` dispatches Brave web DTO responses to `map_web_response`.
+- `src/providers/brave/client.rs:98` dispatches Brave news DTO responses to `map_news_response`.
+- `src/providers/brave/client.rs:102` dispatches Brave image DTO responses to `map_images_response`.
+- `src/providers/brave/client.rs:106` dispatches Brave video DTO responses to `map_videos_response`.
+
+### Exa
+
+- `src/providers/exa/dto.rs:52` defines `ExaSearchResponse`.
+- `src/providers/exa/dto.rs:56` stores Exa response results as `Vec<ExaResult>`.
+- `src/providers/exa/dto.rs:61` defines `ExaResult`.
+- `src/providers/exa/dto.rs:63` defines `ExaResult.url: Option<String>`.
+- `src/providers/exa/client.rs:121` dispatches Exa web responses to `map_web_response`.
+- `src/providers/exa/client.rs:123` dispatches Exa news responses to `map_news_response`.
+- `src/providers/exa/client.rs:97` reports Exa capabilities.
+- `src/providers/exa/client.rs:101` sets Exa image support to `false`.
+- `src/providers/exa/client.rs:102` sets Exa video support to `false`.
+
+## Mapping Paths
+
+### Brave DTO To Domain
+
+- `src/providers/brave/mapper.rs:7` defines `map_web_response`.
+- `src/providers/brave/mapper.rs:19` creates `SearchResult::Web`.
+- `src/providers/brave/mapper.rs:21` maps `BraveWebResult.url` into `WebResult.url` with `unwrap_or_default()`.
+- `src/providers/brave/mapper.rs:30` defines `map_news_response`.
+- `src/providers/brave/mapper.rs:41` creates `SearchResult::News`.
+- `src/providers/brave/mapper.rs:43` maps `BraveNewsResult.url` into `NewsResult.url` with `unwrap_or_default()`.
+- `src/providers/brave/mapper.rs:53` defines `map_images_response`.
+- `src/providers/brave/mapper.rs:64` creates `SearchResult::Image`.
+- `src/providers/brave/mapper.rs:66` maps `BraveImageResult.url` into `ImageResult.url` with `unwrap_or_default()`.
+- `src/providers/brave/mapper.rs:75` defines `map_videos_response`.
+- `src/providers/brave/mapper.rs:86` creates `SearchResult::Video`.
+- `src/providers/brave/mapper.rs:88` maps `BraveVideoResult.url` into `VideoResult.url` with `unwrap_or_default()`.
+
+### Exa DTO To Domain
+
+- `src/providers/exa/mapper.rs:10` defines `map_web_response`.
+- `src/providers/exa/mapper.rs:12` creates `SearchResult::Web`.
+- `src/providers/exa/mapper.rs:14` maps `ExaResult.url` into `WebResult.url` with `unwrap_or_default()`.
+- `src/providers/exa/mapper.rs:21` defines `map_news_response`.
+- `src/providers/exa/mapper.rs:23` creates `SearchResult::News`.
+- `src/providers/exa/mapper.rs:25` maps `ExaResult.url` into `NewsResult.url` with `unwrap_or_default()`.
+- `src/providers/exa/mapper.rs:33` defines the shared `map_response` helper.
+- `src/providers/exa/mapper.rs:42` maps `dto.results` into normalized `SearchResult` values.
+
+## Application Preservation Path
+
+- `src/app/search_service.rs:13` defines `SearchService::search`.
+- `src/app/search_service.rs:15` calls `self.provider.search(&query).await`.
+- `src/app/search_service.rs:19` returns the provider result without rebuilding `SearchResponse`.
+- `src/app/fanout_search_service.rs:14` defines `FanoutSearchService::search_all`.
+- `src/app/fanout_search_service.rs:20` calls each provider search.
+- `src/app/fanout_search_service.rs:21` pushes successful provider `SearchResponse` values into `responses`.
+- `src/app/fanout_search_service.rs:29` returns `SearchBatchResponse` with the collected `responses`.
+
+## CLI Rendering Path
+
+- `src/cli/output.rs:3` defines `render_text(&SearchResponse) -> String`.
+- `src/cli/output.rs:12` matches `SearchResult::Web`.
+- `src/cli/output.rs:14` renders web result URLs as `URL: {r.url}`.
+- `src/cli/output.rs:22` matches `SearchResult::News`.
+- `src/cli/output.rs:24` renders news result URLs as `URL: {r.url}`.
+- `src/cli/output.rs:35` matches `SearchResult::Image`.
+- `src/cli/output.rs:37` renders image result URLs as `URL: {r.url}`.
+- `src/cli/output.rs:39` matches `SearchResult::Video`.
+- `src/cli/output.rs:41` renders video result URLs as `URL: {r.url}`.
+- `src/cli/output.rs:49` defines `render_fanout_text(&SearchBatchResponse) -> String`.
+- `src/cli/output.rs:57` iterates successful provider responses.
+- `src/cli/output.rs:59` renders each provider response by calling `render_text(provider_response)`.
+- `src/cli/runner.rs:72` handles a successful single-provider search response.
+- `src/cli/runner.rs:75` prints `render_text(&response)` to stdout.
+- `src/cli/runner.rs:97` obtains a fan-out `SearchBatchResponse`.
+- `src/cli/runner.rs:103` prints `render_fanout_text(&response)` to stdout.
+
+## Patterns Found
+
+- Domain URL field pattern: all normalized result structs carry `url: String` at `src/domain/result.rs:39`, `src/domain/result.rs:47`, `src/domain/result.rs:56`, and `src/domain/result.rs:64`.
+- Provider DTO URL field pattern: Brave DTOs carry `Option<String>` URL fields at `src/providers/brave/dto.rs:23`, `src/providers/brave/dto.rs:43`, `src/providers/brave/dto.rs:59`, and `src/providers/brave/dto.rs:84`; Exa carries `Option<String>` at `src/providers/exa/dto.rs:63`.
+- Mapper defaulting pattern: provider optional URL fields are converted with `unwrap_or_default()` at `src/providers/brave/mapper.rs:21`, `src/providers/brave/mapper.rs:43`, `src/providers/brave/mapper.rs:66`, `src/providers/brave/mapper.rs:88`, `src/providers/exa/mapper.rs:14`, and `src/providers/exa/mapper.rs:25`.
+- Text renderer URL-line pattern: CLI output prints an explicit `URL:` line for web, news, image, and video results at `src/cli/output.rs:14`, `src/cli/output.rs:24`, `src/cli/output.rs:37`, and `src/cli/output.rs:41`.
+- Fan-out reuse pattern: fan-out output delegates each successful provider response to the same single-provider renderer at `src/cli/output.rs:59`.
+- App pass-through pattern: the app layer does not inspect individual `SearchResult` fields in `src/app/search_service.rs:15` or `src/app/fanout_search_service.rs:21`.
+
+## Dependencies
+
+- CLI single-provider path: `src/cli/runner.rs:72` -> `SearchService::search` at `src/app/search_service.rs:13` -> `SearchProvider::search` at `src/domain/provider.rs:23` -> provider mapper -> `SearchResponse` -> `render_text` at `src/cli/output.rs:3`.
+- CLI fan-out path: `src/cli/runner.rs:97` -> `FanoutSearchService::search_all` at `src/app/fanout_search_service.rs:14` -> provider `SearchResponse` values in `SearchBatchResponse.responses` -> `render_fanout_text` at `src/cli/output.rs:49` -> `render_text` at `src/cli/output.rs:59`.
+- Brave URL path: `src/providers/brave/client.rs:93` through `src/providers/brave/client.rs:108` -> `src/providers/brave/mapper.rs:7`, `src/providers/brave/mapper.rs:30`, `src/providers/brave/mapper.rs:53`, or `src/providers/brave/mapper.rs:75` -> domain result URL fields in `src/domain/result.rs`.
+- Exa URL path: `src/providers/exa/client.rs:121` through `src/providers/exa/client.rs:123` -> `src/providers/exa/mapper.rs:10` or `src/providers/exa/mapper.rs:21` -> domain web/news URL fields in `src/domain/result.rs`.
+
+## Tests Found
+
+- `src/cli/output.rs:80` defines `test_render_text_mixed_results`.
+- `src/cli/output.rs:86` constructs a web result with `https://rust-lang.org`.
+- `src/cli/output.rs:92` constructs a news result with `https://example.com/news`.
+- `src/cli/output.rs:99` constructs an image result with `https://example.com/img.png`.
+- `src/cli/output.rs:105` constructs a video result with `https://example.com/video`.
+- `src/cli/output.rs:120` asserts the rendered text contains `https://rust-lang.org`.
+- `src/cli/output.rs:128` defines `test_render_fanout_text_includes_successes_and_failures`.
+- `src/cli/output.rs:134` constructs a fan-out web result with `https://rust-lang.org`.
+- `src/providers/brave/mapper.rs:108` defines `test_map_web_response`.
+- `src/providers/brave/mapper.rs:116` sets a Brave web DTO URL to `https://rust-lang.org`.
+- `src/providers/brave/mapper.rs:131` asserts the mapped web result URL is `https://rust-lang.org`.
+- `src/providers/brave/mapper.rs:140` defines `test_map_news_response`.
+- `src/providers/brave/mapper.rs:148` sets a Brave news DTO URL to `https://example.com/news`.
+- `src/providers/brave/mapper.rs:169` defines `test_map_images_response`.
+- `src/providers/brave/mapper.rs:176` sets a Brave image DTO URL to `https://example.com/img.png`.
+- `src/providers/brave/mapper.rs:199` defines `test_map_videos_response`.
+- `src/providers/brave/mapper.rs:207` sets a Brave video DTO URL to `https://example.com/video`.
+- `src/providers/brave/client.rs:160` defines `test_brave_provider_web_search`.
+- `src/providers/brave/client.rs:165` includes `https://rust-lang.org` in the mocked Brave JSON response.
+- `src/providers/brave/client.rs:196` asserts the provider response web result URL is `https://rust-lang.org`.
+- `src/providers/exa/dto.rs:77` defines `test_exa_search_response_deserializes_minimal_payload`.
+- `src/providers/exa/dto.rs:84` includes `https://example.com` in mocked Exa JSON.
+- `src/providers/exa/dto.rs:99` asserts Exa DTO deserialization preserves the URL field.
+- `src/providers/exa/mapper.rs:97` defines `sample_result`.
+- `src/providers/exa/mapper.rs:100` sets the sample Exa result URL to `https://example.com/news`.
+- `src/providers/exa/mapper.rs:110` defines `test_map_news_response_prefers_summary_and_preserves_author`.
+- `src/providers/exa/mapper.rs:131` asserts the mapped Exa news result URL is `https://example.com/news`.
+- `tests/integration/search_service_test.rs:83` defines `web_result(title, url, snippet)`.
+- `tests/integration/search_service_test.rs:86` maps the helper URL argument into `WebResult.url`.
+- `tests/integration/search_service_test.rs:131` defines `search_service_preserves_result_count`.
+- `tests/integration/search_service_test.rs:136` constructs a web result with `https://example.com/1`.
+- `tests/integration/search_service_test.rs:137` constructs a web result with `https://example.com/2`.
+
+## Symbol Index
+
+- `src/domain/result.rs:7` -> `SearchResponse`
+- `src/domain/result.rs:16` -> `SearchBatchResponse`
+- `src/domain/result.rs:23` -> `ProviderSearchFailure`
+- `src/domain/result.rs:29` -> `SearchResult`
+- `src/domain/result.rs:37` -> `WebResult`
+- `src/domain/result.rs:45` -> `NewsResult`
+- `src/domain/result.rs:54` -> `ImageResult`
+- `src/domain/result.rs:62` -> `VideoResult`
+- `src/domain/provider.rs:18` -> `SearchProvider`
+- `src/providers/brave/mapper.rs:7` -> `map_web_response`
+- `src/providers/brave/mapper.rs:30` -> `map_news_response`
+- `src/providers/brave/mapper.rs:53` -> `map_images_response`
+- `src/providers/brave/mapper.rs:75` -> `map_videos_response`
+- `src/providers/exa/mapper.rs:10` -> `map_web_response`
+- `src/providers/exa/mapper.rs:21` -> `map_news_response`
+- `src/cli/output.rs:3` -> `render_text`
+- `src/cli/output.rs:49` -> `render_fanout_text`
+
+## Structural Scan Notes
+
+- Ran `/Users/tuna/.codex/skills/research-phase/scripts/structure-map.sh ./ --with-stats`; the script reported 108 Rust files and 118 total code files.
+- Ran `/Users/tuna/.codex/skills/research-phase/scripts/ast-scan.sh all src/`; the script listed functions and test helper structs across `src/`, including `src/cli/output.rs`, `src/domain/result.rs`, provider mappers, provider clients, and app services.
+- Ran `/Users/tuna/.codex/skills/research-phase/scripts/symbol-index.sh src/`; the script returned no exported functions/classes/types/constants for this Rust tree, so the symbol index above comes from numbered source reads.
+- Ran `rg -n "SearchResult|SearchResults|result|results|url|link|render_text|print|stdout|provider all|Document|SearchContent|source|href" src tests docs README.md Cargo.toml` to locate URL/result/output references.
+
+## Observed Current Behavior Surface
+
+- Normalized domain result structs already contain a `url: String` field for every current result variant.
+- Brave DTO URL fields are optional and are mapped into domain URL strings for web, news, image, and video results.
+- Exa DTO URL fields are optional and are mapped into domain URL strings for web and news results.
+- Mapper code converts missing provider URL fields to empty strings.
+- Single-provider CLI text output includes a `URL:` line for every current result variant.
+- Fan-out CLI text output includes URLs through its call to the single-provider renderer.
+- The app layer preserves provider `SearchResponse` values without per-result URL handling.

--- a/docs/artifacts/memory/MEM-20260531-result-url-implementation.md
+++ b/docs/artifacts/memory/MEM-20260531-result-url-implementation.md
@@ -22,7 +22,7 @@ ontology_relations:
 | Date | 2026-05-31 |
 | Owner | Codex |
 | Related Artifacts | `docs/artifacts/active/CHARTER-20260531-result-url-list.md`, `docs/artifacts/active/EXEC-20260531-result-url-list.md`, `docs/artifacts/evidence/EVID-20260531-result-url-list.md` |
-| Related Files | `src/cli/output.rs` |
+| Related Files | `src/cli/output.rs`, `CHANGELOG.md` |
 
 ## Decisions
 
@@ -31,6 +31,7 @@ ontology_relations:
 - Added a local `result_url` helper rather than adding methods to domain result types.
 - Appended a final `URLs:` block only when at least one result has a non-empty trimmed URL.
 - Left `render_fanout_text` unchanged because it already delegates each successful provider response to `render_text`.
+- Added PR `#20` to `CHANGELOG.md` before merge.
 
 ## Constraints
 
@@ -44,6 +45,7 @@ ontology_relations:
 
 - `src/cli/output.rs`: `render_text` now appends a final `URLs:` block after result details, using a local `result_url` helper and skipping empty summary entries.
 - `src/cli/output.rs`: added `render_text_appends_url_list_at_end` to prove final block shape, order, and whitespace-only URL skipping.
+- `CHANGELOG.md`: added the unreleased result URL list entry with PR `#20`.
 - `docs/artifacts/active/EXEC-20260531-result-url-list.md`: execution log for this implementation session.
 - `docs/artifacts/evidence/EVID-20260531-result-url-list.md`: validation evidence.
 - `docs/artifacts/memory/MEM-20260531-result-url-implementation.md`: this memory record.
@@ -54,6 +56,7 @@ ontology_relations:
 - Focused renderer test passed: `cargo test render_text_appends_url_list_at_end`.
 - Full Rust suite passed through `cargo test` during `just check`.
 - Canonical gate passed: `just check`.
+- Changelog coverage passed after the PR-number follow-up: `cargo test --test changelog_test`.
 - Final markdown frontmatter check passed: `python3 scripts/check_markdown_frontmatter.py`.
 
 ## Open Issues

--- a/docs/artifacts/memory/MEM-20260531-result-url-implementation.md
+++ b/docs/artifacts/memory/MEM-20260531-result-url-implementation.md
@@ -1,0 +1,67 @@
+---
+title: "Session memory: result URL list implementation"
+when_to_read:
+  - "When continuing after the result URL list implementation session."
+  - "When changing CLI text output for search results."
+summary: "Records the implementation session that added a final URL summary block to rendered CLI search results."
+ontology_relations:
+  - relation: "summarizes"
+    target: "docs/artifacts/active/CHARTER-20260531-result-url-list.md"
+    note: "Captures the completed execution session for the active result URL list charter."
+  - relation: "supported_by"
+    target: "docs/artifacts/evidence/EVID-20260531-result-url-list.md"
+    note: "Points to validation evidence for this implementation session."
+---
+
+# Session Memory
+
+| Field | Value |
+|---|---|
+| Artifact Type | Session Memory |
+| Status | Completed |
+| Date | 2026-05-31 |
+| Owner | Codex |
+| Related Artifacts | `docs/artifacts/active/CHARTER-20260531-result-url-list.md`, `docs/artifacts/active/EXEC-20260531-result-url-list.md`, `docs/artifacts/evidence/EVID-20260531-result-url-list.md` |
+| Related Files | `src/cli/output.rs` |
+
+## Decisions
+
+- Kept the feature entirely in `src/cli/output.rs`.
+- Kept existing inline per-result `URL:` lines unchanged.
+- Added a local `result_url` helper rather than adding methods to domain result types.
+- Appended a final `URLs:` block only when at least one result has a non-empty trimmed URL.
+- Left `render_fanout_text` unchanged because it already delegates each successful provider response to `render_text`.
+
+## Constraints
+
+- No dependencies were added.
+- Domain, provider, transport, app, bootstrap, CLI argument, and runner code stayed unchanged.
+- URL summary entries are trimmed for display and whitespace-only URLs are skipped.
+- Duplicate URLs remain preserved because the implementation iterates `response.results` without de-duplication.
+- A rollback commit was not created because the worktree already contained uncommitted documentation/artifact changes before implementation started.
+
+## Files Changed
+
+- `src/cli/output.rs`: `render_text` now appends a final `URLs:` block after result details, using a local `result_url` helper and skipping empty summary entries.
+- `src/cli/output.rs`: added `render_text_appends_url_list_at_end` to prove final block shape, order, and whitespace-only URL skipping.
+- `docs/artifacts/active/EXEC-20260531-result-url-list.md`: execution log for this implementation session.
+- `docs/artifacts/evidence/EVID-20260531-result-url-list.md`: validation evidence.
+- `docs/artifacts/memory/MEM-20260531-result-url-implementation.md`: this memory record.
+
+## Evidence / Tests
+
+- Evidence pack: `docs/artifacts/evidence/EVID-20260531-result-url-list.md`.
+- Focused renderer test passed: `cargo test render_text_appends_url_list_at_end`.
+- Full Rust suite passed through `cargo test` during `just check`.
+- Canonical gate passed: `just check`.
+- Final markdown frontmatter check passed: `python3 scripts/check_markdown_frontmatter.py`.
+
+## Open Issues
+
+- No live Brave or Exa API calls were run.
+- Existing unrelated/untracked artifact and docs changes remain in the worktree.
+
+## Future Agent Notes
+
+- Fan-out currently shows one `URLs:` block inside each successful provider section. Do not add a global fan-out URL list unless a new charter explicitly asks for it.
+- Keep URL validation, normalization, sorting, and de-duplication out of this renderer unless requirements change.

--- a/docs/artifacts/memory/MEM-20260531-result-url-plan.md
+++ b/docs/artifacts/memory/MEM-20260531-result-url-plan.md
@@ -1,0 +1,63 @@
+---
+title: "Session memory: result URL list plan"
+when_to_read:
+  - "When implementing the result URL list output change."
+  - "When checking why the result URL list change is scoped to CLI rendering."
+summary: "Summarizes the planning-only session that created the active charter for appending a compact URL list to CLI result output."
+ontology_relations:
+  - relation: "summarizes"
+    target: "docs/artifacts/active/CHARTER-20260531-result-url-list.md"
+    note: "Records the session that created the result URL list implementation charter."
+  - relation: "follows_from"
+    target: "docs/artifacts/explorations/EXP-20260531-result-url-surface.md"
+    note: "Builds on the research showing result URLs already flow through the system."
+---
+
+# Session Memory
+
+| Field | Value |
+|---|---|
+| Artifact Type | Session Memory |
+| Status | Completed |
+| Date | 2026-05-31 |
+| Owner | Codex |
+| Related Artifacts | `docs/artifacts/active/CHARTER-20260531-result-url-list.md`, `docs/artifacts/explorations/EXP-20260531-result-url-surface.md`, `docs/artifacts/memory/MEM-20260531-result-url-research.md` |
+| Related Files | `src/cli/output.rs`, `src/domain/result.rs`, `docs/process/RULES.md`, `docs/process/WORKFLOW.md`, `docs/artifacts/INDEX.md` |
+
+## Decisions
+
+- No durable technical decision was made.
+- The implementation plan treats the requested URL list as a CLI rendering change only.
+- The plan assumes fan-out output should inherit one URL list per successful provider section through the existing `render_text` delegation.
+
+## Constraints
+
+- No source code was changed in this planning session.
+- Future implementation should keep the code change localized to `src/cli/output.rs`.
+- Future implementation should not change domain structs, provider mappers, app services, CLI arguments, or provider selection.
+- The final URL list should skip empty URL strings and preserve result order.
+
+## Files Changed
+
+- `docs/artifacts/active/CHARTER-20260531-result-url-list.md`: added the active feature charter and minimal implementation plan.
+- `docs/artifacts/memory/MEM-20260531-result-url-plan.md`: added this planning-session memory.
+
+## Evidence / Tests
+
+- Read the `plan-phase` skill instructions and adapted them to this repository's `docs/artifacts/active/CHARTER-*` convention.
+- Read `docs/process/RULES.md`, `docs/process/WORKFLOW.md`, `docs/artifacts/INDEX.md`, and the session charter template.
+- Read `docs/artifacts/explorations/EXP-20260531-result-url-surface.md` and confirmed the plan matches its findings.
+- Read `src/cli/output.rs` and `src/domain/result.rs` to ground the plan in the current renderer and result shapes.
+- Ran `python3 scripts/check_markdown_frontmatter.py`; it passed.
+- Did not run `just check` because this session only added planning and memory markdown artifacts.
+
+## Open Issues
+
+- Implementation is still pending.
+- Future execution still needs an execution log, evidence pack, and implementation session memory before claiming the code change is done.
+
+## Future Agent Notes
+
+- The intended minimal code path is to modify `render_text` only.
+- A small local helper or match expression can extract `url` from all `SearchResult` variants without changing domain types.
+- The plan intentionally does not include de-duplication, URL validation, or a global fan-out URL list.

--- a/docs/artifacts/memory/MEM-20260531-result-url-research.md
+++ b/docs/artifacts/memory/MEM-20260531-result-url-research.md
@@ -1,0 +1,53 @@
+---
+title: "Session memory: result URL research"
+when_to_read:
+  - "When continuing work on URLs included in search results."
+summary: "Summarizes the exploration-only research that mapped provider-returned URLs through domain results, app services, and CLI output."
+uuid: "E34FAF94-9829-445E-8506-969CC613B214"
+created_at: "2026-05-31T11:17:16-05:00"
+ontology_relations:
+  - relation: "summarizes"
+    target: "docs/artifacts/explorations/EXP-20260531-result-url-surface.md"
+    note: "Records the session that created the result URL surface research artifact."
+---
+
+# Session Memory
+
+| Field | Value |
+|---|---|
+| Artifact Type | Session Memory |
+| Status | Completed |
+| Date | 2026-05-31 |
+| Owner | Codex |
+| Related Artifacts | `docs/artifacts/explorations/EXP-20260531-result-url-surface.md` |
+| Related Files | `src/domain/result.rs`, `src/providers/brave/dto.rs`, `src/providers/brave/mapper.rs`, `src/providers/exa/dto.rs`, `src/providers/exa/mapper.rs`, `src/app/search_service.rs`, `src/app/fanout_search_service.rs`, `src/cli/output.rs`, `src/cli/runner.rs` |
+
+## Decisions
+
+- No durable technical decision was made.
+- No implementation work was started.
+- The session stayed in research/exploration mode.
+
+## Files Changed
+
+- `docs/artifacts/explorations/EXP-20260531-result-url-surface.md`: added factual research on how result URLs flow from provider DTOs through domain results to CLI output.
+- `docs/artifacts/memory/MEM-20260531-result-url-research.md`: added this session memory.
+
+## Evidence / Validation
+
+- Read repository process and project context docs listed in `AGENTS.md`.
+- Ran the research-phase structure, ast-scan, and symbol-index scripts.
+- Reviewed source files and tests for result URL fields, provider DTO URL fields, mapper behavior, app response preservation, and CLI rendering.
+- Ran direct frontmatter validation for the two new markdown files; it passed.
+- Ran `python3 scripts/check_markdown_frontmatter.py`; it passed for tracked markdown.
+
+## Open Issues
+
+- No code issue was resolved in this session.
+- A future implementation still requires a charter before source edits.
+
+## Future Agent Notes
+
+- The research found that current domain result variants already carry URL strings.
+- The research found that current CLI text rendering already prints a `URL:` line for all current result variants.
+- The research found mapper defaulting from optional provider URL fields to empty strings.

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -43,7 +43,34 @@ pub fn render_text(response: &SearchResponse) -> String {
         }
         lines.push(String::new());
     }
+
+    let urls: Vec<&str> = response
+        .results
+        .iter()
+        .map(result_url)
+        .filter_map(|url| {
+            let trimmed = url.trim();
+            (!trimmed.is_empty()).then_some(trimmed)
+        })
+        .collect();
+
+    if !urls.is_empty() {
+        lines.push("URLs:".to_string());
+        for url in urls {
+            lines.push(format!("- {}", url));
+        }
+    }
+
     lines.join("\n")
+}
+
+fn result_url(result: &SearchResult) -> &str {
+    match result {
+        SearchResult::Web(r) => &r.url,
+        SearchResult::News(r) => &r.url,
+        SearchResult::Image(r) => &r.url,
+        SearchResult::Video(r) => &r.url,
+    }
 }
 
 pub fn render_fanout_text(response: &SearchBatchResponse) -> String {
@@ -122,6 +149,51 @@ mod tests {
         assert!(text.contains("Breaking update"));
         assert!(text.contains("[IMAGE] Rust Logo"));
         assert!(text.contains("[VIDEO] Rust Tutorial"));
+    }
+
+    #[test]
+    fn render_text_appends_url_list_at_end() {
+        let response = SearchResponse {
+            query: "rust".to_string(),
+            provider: "brave".to_string(),
+            results: vec![
+                SearchResult::Web(WebResult {
+                    title: "Rust Lang".to_string(),
+                    url: "https://rust-lang.org".to_string(),
+                    snippet: None,
+                    display_url: None,
+                }),
+                SearchResult::News(NewsResult {
+                    title: "Rust News".to_string(),
+                    url: " https://example.com/news ".to_string(),
+                    snippet: None,
+                    source: None,
+                    published_at: None,
+                }),
+                SearchResult::Image(ImageResult {
+                    title: "Missing URL".to_string(),
+                    url: "   ".to_string(),
+                    thumbnail_url: None,
+                    source: None,
+                }),
+                SearchResult::Video(VideoResult {
+                    title: "Rust Tutorial".to_string(),
+                    url: "https://example.com/video".to_string(),
+                    thumbnail_url: None,
+                    duration: None,
+                    published_at: None,
+                }),
+            ],
+            total_estimated: None,
+            next_page: None,
+        };
+
+        let text = render_text(&response);
+
+        assert!(text.ends_with(
+            "URLs:\n- https://rust-lang.org\n- https://example.com/news\n- https://example.com/video"
+        ));
+        assert!(!text.contains("-    "));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Append a final `URLs:` block to rendered CLI search results using existing normalized result URL fields.
- Preserve existing inline `URL:` lines and result ordering.
- Skip whitespace-only URLs in the final summary list while leaving fan-out behavior provider-local through existing `render_text` delegation.
- Add process artifacts for research, charter, execution, evidence, and session memory.

## Validation

- `cargo test render_text_appends_url_list_at_end`
- `cargo test`
- `just check`
- `python3 scripts/check_markdown_frontmatter.py`

## Notes

No live Brave or Exa API calls were run; the charter explicitly excluded live provider calls.